### PR TITLE
correct the method name in the vote-bar component

### DIFF
--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -33,7 +33,7 @@
             "
             style="width: {{ $rfc->percentage_no }}%;"
             @if($user?->getVoteForRfc($rfc)?->type === \App\Models\VoteType::NO)
-                wire:click="undo('{{ \App\Models\VoteType::NO }}')"
+                wire:click="unDoVote('{{ \App\Models\VoteType::NO }}')"
             @else
                 wire:click="vote('{{ \App\Models\VoteType::NO }}')"
             @endif >

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -33,7 +33,7 @@
             "
             style="width: {{ $rfc->percentage_no }}%;"
             @if($user?->getVoteForRfc($rfc)?->type === \App\Models\VoteType::NO)
-                wire:click="unDoVote('{{ \App\Models\VoteType::NO }}')"
+                wire:click="undo('{{ \App\Models\VoteType::NO }}')"
             @else
                 wire:click="vote('{{ \App\Models\VoteType::NO }}')"
             @endif >


### PR DESCRIPTION
The side of the bar tha supposed to vote for 'no' was using the old name of the method. Now, I have corrected it.