### PR TITLE
Add markdown support for arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "laravel/tinker": "^2.8",
         "livewire/livewire": "^2.11",
         "protonemedia/laravel-form-components": "^3.8",
-        "spatie/laravel-backup": "^8.1"
+        "spatie/laravel-backup": "^8.1",
+        "spatie/laravel-markdown": "^2.3"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7450b446b9e6871b9ee56fdac4d9ce36",
+    "content-hash": "92d5f5f03d7d7d2a3a4d88fd1b5b5c7c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3890,6 +3890,66 @@
             "time": "2023-04-15T23:01:58+00:00"
         },
         {
+            "name": "spatie/commonmark-shiki-highlighter",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/commonmark-shiki-highlighter.git",
+                "reference": "52528a02f61d84030b313b5c7b0c4dd8edca7187"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/commonmark-shiki-highlighter/zipball/52528a02f61d84030b313b5c7b0c4dd8edca7187",
+                "reference": "52528a02f61d84030b313b5c7b0c4dd8edca7187",
+                "shasum": ""
+            },
+            "require": {
+                "league/commonmark": "^2.0",
+                "php": "^8.0",
+                "spatie/shiki-php": "^1.1.1",
+                "symfony/process": "^5.3|^6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "phpunit/phpunit": "^9.5",
+                "spatie/phpunit-snapshot-assertions": "^4.2.7",
+                "spatie/ray": "^1.28"
+            },
+            "type": "commonmark-extension",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\CommonMarkShikiHighlighter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Highlight code blocks with league/commonmark and Shiki",
+            "homepage": "https://github.com/spatie/commonmark-shiki-highlighter",
+            "keywords": [
+                "commonmark-shiki-highlighter",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/commonmark-shiki-highlighter/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-11-28T08:03:04+00:00"
+        },
+        {
             "name": "spatie/db-dumper",
             "version": "3.4.0",
             "source": {
@@ -4052,6 +4112,82 @@
             "time": "2023-06-02T08:56:10+00:00"
         },
         {
+            "name": "spatie/laravel-markdown",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-markdown.git",
+                "reference": "1cdde7aafd638c6df2ee12868635399968035b08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-markdown/zipball/1cdde7aafd638c6df2ee12868635399968035b08",
+                "reference": "1cdde7aafd638c6df2ee12868635399968035b08",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/cache": "^8.49|^9.0|^10.0",
+                "illuminate/contracts": "^8.37|^9.0|^10.0",
+                "illuminate/support": "^8.49|^9.0|^10.0",
+                "illuminate/view": "^8.49|^9.0|^10.0",
+                "league/commonmark": "^2.2",
+                "php": "^8.0",
+                "spatie/commonmark-shiki-highlighter": "^2.0",
+                "spatie/laravel-package-tools": "^1.4.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2",
+                "nunomaduro/collision": "^5.3|^6.0",
+                "orchestra/testbench": "^6.15|^7.0|^8.0",
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.3",
+                "spatie/laravel-ray": "^1.23",
+                "spatie/pest-plugin-snapshots": "^1.1",
+                "vimeo/psalm": "^4.8"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\LaravelMarkdown\\MarkdownServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelMarkdown\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A highly configurable markdown renderer and Blade component for Laravel",
+            "homepage": "https://github.com/spatie/laravel-markdown",
+            "keywords": [
+                "Laravel-Markdown",
+                "laravel",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/laravel-markdown/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-05T08:09:13+00:00"
+        },
+        {
             "name": "spatie/laravel-package-tools",
             "version": "1.15.0",
             "source": {
@@ -4184,6 +4320,69 @@
                 }
             ],
             "time": "2023-01-14T21:10:59+00:00"
+        },
+        {
+            "name": "spatie/shiki-php",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/shiki-php.git",
+                "reference": "34fe61405b405c735c82a9c56feffd3f7c5544ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/shiki-php/zipball/34fe61405b405c735c82a9c56feffd3f7c5544ff",
+                "reference": "34fe61405b405c735c82a9c56feffd3f7c5544ff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.0",
+                "pestphp/pest": "^1.8",
+                "phpunit/phpunit": "^9.5",
+                "spatie/pest-plugin-snapshots": "^1.1",
+                "spatie/ray": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ShikiPhp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rias Van der Veken",
+                    "email": "rias@spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Highlight code using Shiki in PHP",
+            "homepage": "https://github.com/spatie/shiki-php",
+            "keywords": [
+                "shiki",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/shiki-php/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-01T11:28:41+00:00"
         },
         {
             "name": "spatie/temporary-directory",

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -1,0 +1,92 @@
+<?php
+
+return [
+    'code_highlighting' => [
+        /*
+         * To highlight code, we'll use Shiki under the hood. Make sure it's installed.
+         *
+         * More info: https://spatie.be/docs/laravel-markdown/v1/installation-setup
+         */
+        'enabled' => true,
+
+        /*
+         * The name of or path to a Shiki theme
+         *
+         * More info: https://github.com/shikijs/shiki/blob/main/docs/themes.md
+         */
+        'theme' => 'github-light',
+    ],
+
+    /*
+     * When enabled, anchor links will be added to all titles
+     */
+    'add_anchors_to_headings' => false,
+
+    /*
+     * These options will be passed to the league/commonmark package which is
+     * used under the hood to render markdown.
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/using-the-blade-component/passing-options-to-commonmark
+     */
+    'commonmark_options' => [],
+
+    /*
+     * Rendering markdown to HTML can be resource intensive. By default
+     * we'll cache the results.
+     *
+     * You can specify the name of a cache store here. When set to `null`
+     * the default cache store will be used. If you do not want to use
+     * caching set this value to `false`.
+     */
+    'cache_store' => null,
+
+    /*
+     * This class will convert markdown to HTML
+     *
+     * You can change this to a class of your own to greatly
+     * customize the rendering process
+     *
+     * More info: https://spatie.be/docs/laravel-markdown/v1/advanced-usage/customizing-the-rendering-process
+     */
+    'renderer_class' => Spatie\LaravelMarkdown\MarkdownRenderer::class,
+
+    /*
+     * These extensions should be added to the markdown environment. A valid
+     * extension implements League\CommonMark\Extension\ExtensionInterface
+     *
+     * More info: https://commonmark.thephpleague.com/2.4/extensions/overview/
+     */
+    'extensions' => [
+        //
+    ],
+
+    /*
+     * These block renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.4/customization/rendering/
+     */
+    'block_renderers' => [
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
+    ],
+
+    /*
+     * These inline renderers should be added to the markdown environment. A valid
+     * renderer implements League\CommonMark\Renderer\NodeRendererInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.4/customization/rendering/
+     */
+    'inline_renderers' => [
+        // ['class' => FencedCode::class, 'renderer' => MyCustomCodeRenderer::class, 'priority' => 0]
+    ],
+
+    /*
+     * These inline parsers should be added to the markdown environment. A valid
+     * parser implements League\CommonMark\Renderer\InlineParserInterface;
+     *
+     * More info: https://commonmark.thephpleague.com/2.4/customization/inline-parsing/
+     */
+    'inline_parsers' => [
+        // ['parser' => MyCustomInlineParser::class, 'priority' => 0]
+    ],
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "shiki": "^0.14.3"
+            },
             "devDependencies": {
                 "@alpinejs/focus": "^3.10.5",
                 "@tailwindcss/forms": "^0.5.2",
@@ -542,6 +545,11 @@
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
+        },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
@@ -1121,6 +1129,11 @@
                 "jiti": "bin/jiti.js"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        },
         "node_modules/laravel-vite-plugin": {
             "version": "0.7.8",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.8.tgz",
@@ -1609,6 +1622,17 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/shiki": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+            "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+            "dependencies": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -1837,6 +1861,16 @@
             "peerDependencies": {
                 "vite": "^2 || ^3 || ^4"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+        },
+        "node_modules/vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
@@ -2153,6 +2187,11 @@
             "requires": {
                 "@vue/reactivity": "~3.1.1"
             }
+        },
+        "ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
         },
         "any-promise": {
             "version": "1.3.0",
@@ -2562,6 +2601,11 @@
             "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
             "dev": true
         },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        },
         "laravel-vite-plugin": {
             "version": "0.7.8",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.8.tgz",
@@ -2871,6 +2915,17 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "shiki": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+            "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+            "requires": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -3004,6 +3059,16 @@
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
             }
+        },
+        "vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+        },
+        "vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
         "postcss": "^8.4.14",
         "tailwindcss": "^3.1.0",
         "vite": "^4.0.0"
+    },
+    "dependencies": {
+        "shiki": "^0.14.3"
     }
 }

--- a/resources/views/livewire/argument-list.blade.php
+++ b/resources/views/livewire/argument-list.blade.php
@@ -44,9 +44,9 @@
             </div>
 
             <div class="grid gap-2 md:gap-4">
-                <div>
+                <x-markdown class="prose prose-md">
                     {{ $argument->body }}
-                </div>
+                </x-markdown>
                 <small class="flex gap-1 items-center">
                     — <x-user-name :user="$argument->user" />@if($argument->body_updated_at !== null) (edited at {{ $argument->body_updated_at->format("Y-m-d H:i") }})@endif
                 </small>


### PR DESCRIPTION
Pull request adding markdown support for arguments #20 

- Uses spatie/laravel-markdown's blade component to render HTML tags for markdown
- The markdown HTML is styled using Tailwind's typography "prose" class, which is already present in Jetstream. Although a custom class can be used to have more control over the final styling.

Code highlighting is currently done on the client, exploring possibilities of having it on the server side instead but haven't found an easy solution yet.

<img width="1156" alt="Screenshot 2023-08-06 at 10 53 42" src="https://github.com/brendt/rfc-vote/assets/79457016/7867a305-6bee-4e5f-b1e1-8b5626149850">
