### PR TITLE
Update PHP version requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "dg/rss-php": "^1.5",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",


### PR DESCRIPTION
Looking a bit at the code base I noticed that readonly classes are being used, as far as I know that is available only from php 8.2.