### PR TITLE
preventing the user from upvoting themselves.

### DIFF
--- a/app/Actions/CreateArgument.php
+++ b/app/Actions/CreateArgument.php
@@ -29,11 +29,6 @@ final readonly class CreateArgument
                 user: $user,
                 reputationType: ReputationType::CREATE_ARGUMENT,
             );
-
-            (new ToggleArgumentVote)(
-                user: $user,
-                argument: $argument,
-            );
         });
 
         return $argument;

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -28,15 +28,17 @@ final readonly class ToggleArgumentVote
                     reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
                 );
             } else {
-                ArgumentVote::create([
-                    'argument_id' => $argument->id,
-                    'user_id' => $user->id,
-                ]);
+                if (!$argument->wasRecentlyCreated) {
+                    ArgumentVote::create([
+                        'argument_id' => $argument->id,
+                        'user_id' => $user->id,
+                    ]);
 
-                (new AddReputation)(
-                    user: $user,
-                    reputationType: ReputationType::VOTE_FOR_ARGUMENT,
-                );
+                    (new AddReputation)(
+                        user: $user,
+                        reputationType: ReputationType::VOTE_FOR_ARGUMENT,
+                    );
+                }
 
                 (new AddReputation)(
                     user: $argument->user,

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -38,12 +38,12 @@ final readonly class ToggleArgumentVote
                         user: $user,
                         reputationType: ReputationType::VOTE_FOR_ARGUMENT,
                     );
-                }
 
-                (new AddReputation)(
-                    user: $argument->user,
-                    reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
-                );
+                    (new AddReputation)(
+                        user: $argument->user,
+                        reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
+                    );
+                }
             }
 
             $argument->update([

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -28,7 +28,7 @@ final readonly class ToggleArgumentVote
                     reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
                 );
             } else {
-                if (!$argument->wasRecentlyCreated) {
+                if (!$argument->user()->is($user)) {
                     ArgumentVote::create([
                         'argument_id' => $argument->id,
                         'user_id' => $user->id,

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -28,22 +28,20 @@ final readonly class ToggleArgumentVote
                     reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
                 );
             } else {
-                if (! $argument->user()->is($user)) {
-                    ArgumentVote::create([
-                        'argument_id' => $argument->id,
-                        'user_id' => $user->id,
-                    ]);
+                ArgumentVote::create([
+                    'argument_id' => $argument->id,
+                    'user_id' => $user->id,
+                ]);
 
-                    (new AddReputation)(
-                        user: $user,
-                        reputationType: ReputationType::VOTE_FOR_ARGUMENT,
-                    );
+                (new AddReputation)(
+                    user: $user,
+                    reputationType: ReputationType::VOTE_FOR_ARGUMENT,
+                );
 
-                    (new AddReputation)(
-                        user: $argument->user,
-                        reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
-                    );
-                }
+                (new AddReputation)(
+                    user: $argument->user,
+                    reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
+                );
             }
 
             $argument->update([

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -28,7 +28,7 @@ final readonly class ToggleArgumentVote
                     reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
                 );
             } else {
-                if (!$argument->user()->is($user)) {
+                if (! $argument->user()->is($user)) {
                     ArgumentVote::create([
                         'argument_id' => $argument->id,
                         'user_id' => $user->id,

--- a/app/Actions/ToggleArgumentVote.php
+++ b/app/Actions/ToggleArgumentVote.php
@@ -28,7 +28,7 @@ final readonly class ToggleArgumentVote
                     reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
                 );
             } else {
-                if (! $argument->user()->is($user)) {
+                if (!$argument->user()->is($user)) {
                     ArgumentVote::create([
                         'argument_id' => $argument->id,
                         'user_id' => $user->id,
@@ -38,12 +38,12 @@ final readonly class ToggleArgumentVote
                         user: $user,
                         reputationType: ReputationType::VOTE_FOR_ARGUMENT,
                     );
-
-                    (new AddReputation)(
-                        user: $argument->user,
-                        reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
-                    );
                 }
+
+                (new AddReputation)(
+                    user: $argument->user,
+                    reputationType: ReputationType::GAIN_ARGUMENT_VOTE,
+                );
             }
 
             $argument->update([

--- a/app/Http/Livewire/ArgumentList.php
+++ b/app/Http/Livewire/ArgumentList.php
@@ -53,7 +53,7 @@ class ArgumentList extends Component
         }
 
         if ($argument->user()->is($this->user)) {
-           return;
+            return;
         }
 
         (new ToggleArgumentVote)(

--- a/app/Http/Livewire/ArgumentList.php
+++ b/app/Http/Livewire/ArgumentList.php
@@ -52,6 +52,10 @@ class ArgumentList extends Component
             return;
         }
 
+        if ($argument->user()->is($this->user)) {
+           return;
+        }
+
         (new ToggleArgumentVote)(
             user: $this->user,
             argument: $argument,

--- a/tests/Feature/RfcVoteTest.php
+++ b/tests/Feature/RfcVoteTest.php
@@ -69,7 +69,6 @@ class RfcVoteTest extends TestCase
         $this->assertDatabaseHas('users', [
             'reputation' => $user->reputation
                 + ReputationType::CREATE_ARGUMENT->getPoints()
-                + ReputationType::GAIN_ARGUMENT_VOTE->getPoints(),
         ]);
     }
 }

--- a/tests/Feature/RfcVoteTest.php
+++ b/tests/Feature/RfcVoteTest.php
@@ -69,7 +69,6 @@ class RfcVoteTest extends TestCase
         $this->assertDatabaseHas('users', [
             'reputation' => $user->reputation
                 + ReputationType::CREATE_ARGUMENT->getPoints()
-                + ReputationType::VOTE_FOR_ARGUMENT->getPoints()
                 + ReputationType::GAIN_ARGUMENT_VOTE->getPoints(),
         ]);
     }

--- a/tests/Feature/RfcVoteTest.php
+++ b/tests/Feature/RfcVoteTest.php
@@ -68,7 +68,7 @@ class RfcVoteTest extends TestCase
         $this->assertDatabaseCount('arguments', 1);
         $this->assertDatabaseHas('users', [
             'reputation' => $user->reputation
-                + ReputationType::CREATE_ARGUMENT->getPoints()
+                + ReputationType::CREATE_ARGUMENT->getPoints(),
         ]);
     }
 }


### PR DESCRIPTION
as I was navigating through the app trying actions to make sure I don't lose track of the process, I noticed that users are automatically giving their own arguments an upvote right after creating them. which seems counterintuitive in terms of ensuring the credibility of votes on the arguments.