### PR TITLE
Forgot password page redesign

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -7,6 +7,10 @@
         >
             @csrf
 
+            <p class="mb-5 text-gray-500">
+                {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
+            </p>
+
             <x-form.input
                 :label="__('Email')"
                 type="email"

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,34 +1,29 @@
 @component('layouts.base')
-    <x-authentication-card>
-        <x-slot name="logo">
-{{--            <x-authentication-card-logo />--}}
-        </x-slot>
-
-        <div class="mb-4 text-sm text-gray-600">
-            {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
-        </div>
-
-        @if (session('status'))
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ session('status') }}
-            </div>
-        @endif
-
-        <x-validation-errors class="mb-4" />
-
-        <form method="POST" action="{{ route('password.email') }}">
+    <div class="max-w-lg m-auto mt-12">
+        <x-form.wrapper
+            method="POST"
+            action="{{ route('password.email') }}"
+            :heading="__('Reset password')"
+        >
             @csrf
 
-            <div class="block">
-                <x-label for="email" value="{{ __('Email') }}" />
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            </div>
+            <x-form.input
+                :label="__('Email')"
+                type="email"
+                name="email"
+                :value="old('email')"
+                required
+                autofocus
+                :placeholder="__('Enter your email address')"
+                autocomplete="username"
+            />
 
-            <div class="flex items-center justify-end mt-4">
-                <x-button>
-                    {{ __('Email Password Reset Link') }}
-                </x-button>
+            <div class="text-right mt-7">
+                <x-form.button type="submit">
+                    <x-icons.envelope class="w-6 h-6" />
+                    {{ __('Email reset password link') }}
+                </x-form.button>
             </div>
-        </form>
-    </x-authentication-card>
+        </x-form.wrapper>
+    </div>
 @endcomponent

--- a/resources/views/components/icons/envelope.blade.php
+++ b/resources/views/components/icons/envelope.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" {{ $attributes->merge([]) }}>
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+</svg>


### PR DESCRIPTION
Since we redesigned forms on:

- https://github.com/brendt/rfc-vote/pull/79
- https://github.com/brendt/rfc-vote/pull/85
- https://github.com/brendt/rfc-vote/pull/83

This pull request is the redesign of the reset password page with the same reusable blade components.

## Reset password form before
<img width="786" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/e0f07b32-2d92-4b8e-a2ec-534dc0156e9e">

## Reset password form after
<img width="934" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/f04c2e73-64b5-45e1-958d-cc4b9b0b7d9d">

