### PR TITLE
Reset password redesign

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -5,7 +5,7 @@
             action="{{ route('password.email') }}"
             :heading="__('Reset password')"
         >
-            @csrf
+            <x-success-message />
 
             <p class="mb-5 text-gray-500">
                 {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -3,12 +3,12 @@
         <x-form.wrapper
             method="POST"
             action="{{ route('password.email') }}"
-            :heading="__('Reset password')"
+            :heading="__('Forgot your password?')"
         >
             <x-success-message />
 
             <p class="mb-5 text-gray-500">
-                {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
+                {{ __('No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
             </p>
 
             <x-form.input

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,36 +1,49 @@
 @component('layouts.base')
-        <x-authentication-card>
-            <x-slot name="logo">
-{{--                <x-authentication-card-logo />--}}
-            </x-slot>
-
-        <x-validation-errors class="mb-4" />
-
-        <form method="POST" action="{{ route('password.update') }}">
-            @csrf
+    <div class="max-w-lg m-auto mt-12">
+        <x-form.wrapper
+            method="POST"
+            action="{{ route('password.update') }}"
+            :heading="__('Reset Password')"
+        >
+            <x-success-message />
 
             <input type="hidden" name="token" value="{{ $request->route('token') }}">
 
-            <div class="block">
-                <x-label for="email" value="{{ __('Email') }}" />
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus autocomplete="username" />
-            </div>
+            <div class="space-y-4">
+                <x-form.input
+                    :label="__('Email')"
+                    type="email"
+                    name="email"
+                    :value="old('email', $request->email)"
+                    :placeholder="__('Enter your email')"
+                    required autofocus autocomplete="username"
+                />
 
-            <div class="mt-4">
-                <x-label for="password" value="{{ __('Password') }}" />
-                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
-            </div>
+                <x-form.input
+                    :label="__('New password')"
+                    type="password"
+                    name="password"
+                    :placeholder="__('Enter your new password')"
+                    required
+                    autocomplete="new-password"
+                />
 
-            <div class="mt-4">
-                <x-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
-                <x-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
-            </div>
+                <x-form.input
+                    :label="__('Confirm new password')"
+                    type="password"
+                    name="password_confirmation"
+                    :placeholder="__('Confirm your new password')"
+                    required
+                    autocomplete="new-password"
+                />
 
-            <div class="flex items-center justify-end mt-4">
-                <x-button>
-                    {{ __('Reset Password') }}
-                </x-button>
+                <div class="text-right mt-7">
+                    <x-form.button type="submit">
+                        <x-icons.arrow-path class="w-5 h-5" />
+                        {{ __('Reset Password') }}
+                    </x-form.button>
+                </div>
             </div>
-        </form>
-    </x-authentication-card>
+        </x-form.wrapper>
+    </div>
 @endcomponent

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -5,8 +5,6 @@
             action="{{ route('password.update') }}"
             :heading="__('Reset Password')"
         >
-            <x-success-message />
-
             <input type="hidden" name="token" value="{{ $request->route('token') }}">
 
             <div class="space-y-4">

--- a/resources/views/components/icons/arrow-path.blade.php
+++ b/resources/views/components/icons/arrow-path.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" {{ $attributes->merge([]) }}>
+  <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+</svg>

--- a/resources/views/components/success-message.blade.php
+++ b/resources/views/components/success-message.blade.php
@@ -1,0 +1,5 @@
+@if (session('status'))
+    <div class="mb-6 bg-blue-50 border border-blue-100 rounded-md p-4" role="alert">
+        {{ session('status') }}
+    </div>
+@endif

--- a/resources/views/components/success-message.blade.php
+++ b/resources/views/components/success-message.blade.php
@@ -1,5 +1,5 @@
 @if (session('status'))
-    <div class="mb-6 bg-blue-50 border border-blue-100 rounded-md p-4" role="alert">
+    <div class="mb-5 bg-blue-50 border border-blue-100 rounded-md p-4" role="alert">
         {{ session('status') }}
     </div>
 @endif


### PR DESCRIPTION
Since we redesigned forms on:

- https://github.com/brendt/rfc-vote/pull/79
- https://github.com/brendt/rfc-vote/pull/85
- https://github.com/brendt/rfc-vote/pull/83
- https://github.com/brendt/rfc-vote/pull/94

It makes sense to redesign "Reset password" form as well which users sees after he got redirected from his/her email provider to our site.

## Reset password form before
<img width="1198" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/5089b76b-959b-4efb-ba50-c0b2e732f91d">

## Reset password form after
<img width="1136" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/13b44740-c603-49b6-a1c8-5696a05928da">

## Additional changes
Additionally, I've added a successful message to the "Forgot password" form since it was missing. This success message appears when you enter your email in the form and git "Email Reset Password Link" button.
<img width="1024" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/6149039e-57a3-40f3-8d4d-0d46fd41f459">
