### PR TITLE
Enhancement: Updated README for Using Installed Google Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ CHROME_BINARY_PATH=/usr/bin/google-chrome-stable
 NODE_BINARY_PATH=/usr/bin/node
 NPM_BINARY_PATH=/usr/bin/npm
 ```
+
+For macOS (If you want to use Google Chrome):
+```dotenv
+CHROME_BINARY_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+
+
 For horizon to work properly make sure that you have the following in `.env` file:
 ```dotenv
 REDIS_HOST=redis


### PR DESCRIPTION
I made this pull request because I wanted to avoid installing `google-chrome-stable` separately. Instead, I leveraged the already installed Google Chrome. I tested this on my MacBook Air M1, and it worked as expected. Therefore, I've included the necessary changes in the README to reflect this update.