### PR TITLE
fix: redirect to login page on github oauth cancellation

### DIFF
--- a/app/Http/Controllers/SocialiteCallbackController.php
+++ b/app/Http/Controllers/SocialiteCallbackController.php
@@ -3,13 +3,18 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 
 final readonly class SocialiteCallbackController
 {
-    public function __invoke(string $driver)
+    public function __invoke(string $driver, Request $request)
     {
+        if ($request->has('error') || $request->missing('code')) {
+            return redirect()->route('login');
+        }
+
         $socialiteUser = Socialite::driver('github')->user();
 
         $user = User::query()->where('email', $socialiteUser->getEmail())->first();


### PR DESCRIPTION
Currently, If I cancel the GitHub OAuth process it shows `500 - SERVER ERROR`. 

This PR fixes it by redirecting the user to the login page if an error/cancellation has occurred or someone visits the callback link directly.