### PR TITLE
Tailwind custom classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ REDIS_PORT=6379
 # And the following as well
 QUEUE_CONNECTION=redis
 ```
+
+### Styling guides
+
+- For green and red colors for `yes` and `no` votes, use custom colors defined in `tailwind.config.js` file.
+- For global CSS variables, use `_variables.css` file in the `resources/css` directory.

--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -1,0 +1,6 @@
+:root {
+    --color-agree: #0f766e;
+    --color-agree-light: #14b8a6;
+    --color-disagree: #be185d;
+    --color-disagree-light: #f43f5e;
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,5 @@
+@import '_variables.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -30,21 +30,21 @@
                         <div class="bg-gray-200 p-1 rounded-full">
                             <div class="flex font-bold rounded-full overflow-hidden">
                                 <div
-                                    class="p-1 flex-grow bg-gradient-to-r from-teal-700 to-teal-500"
+                                    class="p-1 flex-grow bg-gradient-to-r from-agree to-agree-light"
                                     style="width: {{ $rfc->percentage_yes }}%;"
                                 ></div>
                                 <div
-                                    class="p-1 flex-grow bg-gradient-to-r from-pink-700 to-pink-500"
+                                    class="p-1 flex-grow bg-gradient-to-r from-disagree to-disagree-light"
                                     style="width: {{ $rfc->percentage_no }}%;"
                                 ></div>
                             </div>
                         </div>
 
                         <div class="flex justify-between p-1 px-2 text-sm">
-                            <span class="text-teal-700 font-bold">
+                            <span class="text-agree font-bold">
                                 {{ $rfc->percentage_yes }}%
                             </span>
-                            <span class="text-pink-700 font-bold">
+                            <span class="text-disagree font-bold">
                                 {{ $rfc->percentage_no }}%
                             </span>
                         </div>

--- a/resources/views/livewire/rfc-counter.blade.php
+++ b/resources/views/livewire/rfc-counter.blade.php
@@ -1,4 +1,4 @@
-<x-tag class="{{ $voteType->class(yes: 'bg-teal-700', no: 'bg-pink-700') }} text-white font-bold">
+<x-tag class="{{ $voteType->class(yes: 'bg-agree', no: 'bg-disagree') }} text-white font-bold">
     {{ $count }}
     {{ $voteType->value }}
 </x-tag>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,12 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                'agree': 'var(--color-agree)',
+                'agree-light': 'var(--color-agree-light)',
+                'disagree': 'var(--color-disagree)',
+                'disagree-light': 'var(--color-disagree-light)',
+            },
         },
     },
 


### PR DESCRIPTION
Added 4 CSS global variables for green and red:
![image](https://github.com/brendt/rfc-vote/assets/35465417/c980426b-9313-4093-8b70-b355cc2c4d5a)

Also added them to tailwind.config.js config so that we can use them globally:
```js
colors: {
    'agree': 'var(--color-agree)',
    'agree-light': 'var(--color-agree-light)',
    'disagree': 'var(--color-disagree)',
    'disagree-light': 'var(--color-disagree-light)',
},
```

On home page, I've changed Tailwind utility classes like teal and pink to our global classes. Visually, nothing has changed.