### PR TITLE
Rfc vote bar redesign

### DIFF
--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -1,5 +1,5 @@
 :root {
-    --color-agree: #129087;
+    --color-agree: #0f766e;
     --color-agree-light: #14b8a6;
     --color-disagree: #d11a66;
     --color-disagree-light: #f43f5e;

--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -1,6 +1,6 @@
 :root {
-    --color-agree: #0f766e;
+    --color-agree: #129087;
     --color-agree-light: #14b8a6;
-    --color-disagree: #be185d;
+    --color-disagree: #d11a66;
     --color-disagree-light: #f43f5e;
 }

--- a/resources/views/components/icons/information-circle.blade.php
+++ b/resources/views/components/icons/information-circle.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" {{ $attributes }}>
+  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+</svg>

--- a/resources/views/livewire/argument-list.blade.php
+++ b/resources/views/livewire/argument-list.blade.php
@@ -1,12 +1,14 @@
 <div class="grid gap-4 md:gap-6">
     @if($user)
-    <div class="px-8">
-        @php
-            $availableVotes = $user->getAvailableVotesForRfc($rfc);
-        @endphp
+        <div class="px-2">
+            @php
+                $availableVotes = $user->getAvailableVotesForRfc($rfc);
+            @endphp
 
-        You have {{ $availableVotes }} {{ Str::plural('vote', $availableVotes) }} available.
-    </div>
+            <span class="text-gray-600 tracking-wide">
+                You have {{ $availableVotes }} {{ Str::plural('vote', $availableVotes) }} available
+            </span>
+        </div>
     @endif
 
     @if($userArgument)

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -12,7 +12,7 @@
             @class([
                 'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full bg-gradient-to-r from-agree to-agree-light text-white hover:opacity-100 transition-opacity duration-300',
                 'cursor-not-allowed opacity-100' => $hasVoted,
-                'hover:bg-green-600 cursor-pointer opacity-70' => ! $hasVoted,
+                'hover:bg-green-600 cursor-pointer opacity-80' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_yes }}%;"
 
@@ -28,7 +28,7 @@
             @class([
                 'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%]min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100 transition-opacity duration-300',
                 'cursor-not-allowed opacity-100' => $hasVoted,
-                'hover:bg-red-600 cursor-pointer opacity-70' => ! $hasVoted,
+                'hover:bg-red-600 cursor-pointer opacity-80' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_no }}%;"
 
@@ -41,16 +41,20 @@
     </div>
 
     @if($voteType)
-        <div class="flex justify-center mt-6 font-bold items-baseline gap-1">
-            {{ $userArgument ? "You've voted" : "You're voting" }}&nbsp;<span @class([
-                'p-1 px-3 rounded-full text-white shadow-md',
-                'bg-green-500' => $voteType === App\Models\VoteType::YES,
-                'bg-red-500' => $voteType === App\Models\VoteType::NO,
-            ])>{{ $voteType->value }}</span>@if(!$userArgument)
-                Next, give your arguments:
-            @else
-                !
-            @endif
+        <div class="flex justify-center mt-5 items-center gap-1">
+            <span class="text-gray-600 tracking-wide">
+                {{ $userArgument ? "You've voted" : "You're voting" }}
+            </span>
+
+            <span @class([
+                'uppercase ml-1 font-black text-lg',
+                'text-agree' => $voteType === App\Models\VoteType::YES,
+                'text-disagree' => $voteType === App\Models\VoteType::NO,
+            ])>
+                {{ $voteType->value }}
+            </span>
+
+            {{ $userArgument ? '!' : '! Please, give your arguments below:' }}
         </div>
     @endif
 

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -1,17 +1,18 @@
 <div>
     @if (!$voteType)
-        <div class="font-bold mb-3 flex justify-center">
-            Click the bar to cast your vote!
+        <div class="mb-3 text-gray-600 tracking-wide flex gap-2 items-center justify-center">
+            <x-icons.information-circle class="w-6 h-6" />
+            {{ __('Click the bar to cast your vote!') }}
         </div>
     @endif
 
-    <div class="flex shadow-xl font-bold rounded-full overflow-hidden">
+    <div class="flex shadow-lg font-bold rounded-full overflow-hidden p-1.5 lg:p-3 bg-gray-200 max-w-[1100px] mx-auto">
+        {{-- Left (green) bar --}}
         <div
             @class([
-                'p-4 flex-grow text-left md:min-w-[15%] min-w-[20%]',
-                'hover:bg-green-600 hover:text-white cursor-pointer' => ! $hasVoted,
-                'bg-green-600 text-white' => $voteType === App\Models\VoteType::YES,
-                'bg-green-300 text-green-900' => $voteType !== App\Models\VoteType::YES,
+                'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full bg-gradient-to-r from-agree to-agree-light text-white hover:opacity-100 transition-opacity duration-300',
+                'cursor-not-allowed opacity-100' => $hasVoted,
+                'hover:bg-green-600 cursor-pointer opacity-70' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_yes }}%;"
 
@@ -22,18 +23,19 @@
             {{ $rfc->percentage_yes }}%
         </div>
 
+        {{-- Right (red) bar --}}
         <div
             @class([
-                'p-4 flex-grow text-right md:min-w-[15%]min-w-[20%]',
-                'hover:bg-red-600 hover:text-white cursor-pointer' => ! $hasVoted,
-                'bg-red-600 text-white' => $voteType === App\Models\VoteType::NO,
-                'bg-red-300 text-red-900' => $voteType !== App\Models\VoteType::NO,
+                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%]min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100 transition-opacity duration-300',
+                'cursor-not-allowed opacity-100' => $hasVoted,
+                'hover:bg-red-600 cursor-pointer opacity-70' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_no }}%;"
 
             @if(! $hasVoted)
                 wire:click="vote('{{ \App\Models\VoteType::NO }}')"
-            @endif >
+            @endif
+        >
             {{ $rfc->percentage_no }}%
         </div>
     </div>

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -26,7 +26,7 @@
         {{-- Right (red) bar --}}
         <div
             @class([
-                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%]min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100',
+                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%] min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100',
                 'cursor-not-allowed opacity-100' => $hasVoted,
                 'hover:bg-red-600 cursor-pointer opacity-80 shadow-md hover:shadow-[0px_0px_7px_var(--color-disagree-light)]' => ! $hasVoted,
             ])

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -10,9 +10,9 @@
         {{-- Left (green) bar --}}
         <div
             @class([
-                'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full bg-gradient-to-r from-agree to-agree-light text-white hover:opacity-100 transition-opacity duration-300',
+                'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full text-white bg-agree-light transition-colors duration-300',
                 'cursor-not-allowed opacity-100' => $hasVoted,
-                'hover:bg-green-600 cursor-pointer opacity-80' => ! $hasVoted,
+                'hover:bg-agree cursor-pointer opacity-80' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_yes }}%;"
 
@@ -26,9 +26,9 @@
         {{-- Right (red) bar --}}
         <div
             @class([
-                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%]min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100 transition-opacity duration-300',
-                'cursor-not-allowed opacity-100' => $hasVoted,
-                'hover:bg-red-600 cursor-pointer opacity-80' => ! $hasVoted,
+                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%] min-w-[20%] rounded-r-full bg-disagree-light text-white transition-colors duration-300',
+                'cursor-not-allowed' => $hasVoted,
+                'hover:bg-disagree cursor-pointer' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_no }}%;"
 

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -10,34 +10,27 @@
             @class([
                 'p-4 flex-grow text-left md:min-w-[15%] min-w-[20%]',
                 'hover:bg-green-600 hover:text-white cursor-pointer' => ! $hasVoted,
-                $voteType === App\Models\VoteType::YES ? 'bg-green-600 text-white' : 'bg-green-300 text-green-900',
+                'bg-green-600 text-white' => $voteType === App\Models\VoteType::YES,
+                'bg-green-300 text-green-900' => $voteType !== App\Models\VoteType::YES,
             ])
             style="width: {{ $rfc->percentage_yes }}%;"
 
             @if(! $hasVoted)
-                wire:click="vote('{{ \App\Models\VoteType::YES }}')"
+                wire:click="vote('{{ App\Models\VoteType::YES }}')"
             @endif
         >
             {{ $rfc->percentage_yes }}%
         </div>
 
         <div
-            class="
-                    p-4 flex-grow text-right
-                    md:min-w-[15%]
-                    min-w-[20%]
-
-                    @if(! $hasVoted)
-                    hover:bg-red-600 hover:text-white cursor-pointer
-                    @endIf
-
-                    @if($voteType === \App\Models\VoteType::NO)
-                    bg-red-600 text-white
-                    @else
-                    bg-red-300 text-red-900
-                    @endif
-                "
+            @class([
+                'p-4 flex-grow text-right md:min-w-[15%]min-w-[20%]',
+                'hover:bg-red-600 hover:text-white cursor-pointer' => ! $hasVoted,
+                'bg-red-600 text-white' => $voteType === App\Models\VoteType::NO,
+                'bg-red-300 text-red-900' => $voteType !== App\Models\VoteType::NO,
+            ])
             style="width: {{ $rfc->percentage_no }}%;"
+
             @if(! $hasVoted)
                 wire:click="vote('{{ \App\Models\VoteType::NO }}')"
             @endif >
@@ -49,8 +42,8 @@
         <div class="flex justify-center mt-6 font-bold items-baseline gap-1">
             {{ $userArgument ? "You've voted" : "You're voting" }}&nbsp;<span @class([
                 'p-1 px-3 rounded-full text-white shadow-md',
-                'bg-green-500' => $voteType === \App\Models\VoteType::YES,
-                'bg-red-500' => $voteType === \App\Models\VoteType::NO,
+                'bg-green-500' => $voteType === App\Models\VoteType::YES,
+                'bg-red-500' => $voteType === App\Models\VoteType::NO,
             ])>{{ $voteType->value }}</span>@if(!$userArgument)
                 Next, give your arguments:
             @else
@@ -61,41 +54,27 @@
 
     @if(!$userArgument && $voteType)
         <div class="flex {{ $voteType->getJustify() }} mt-6">
-            <div class="
-                flex-1
-                p-4 flex gap-4
-                items-end
-                {{ $voteType->getJustify() }}
-                bg-white
-            border-gray-200
-            @if ($voteType === \App\Models\VoteType::YES)
-                border-l-green-400
-                border-l-8
-                md:mr-8
-            @else
-                border-r-red-400
-                border-r-8
-                md:ml-8
-            @endif
-            shadow-md
-            p-4 gap-4 items-center
-        ">
+            <div @class([
+                'flex-1 p-4 flex gap-4 items-end bg-white border-gray-200 shadow-md p-4 gap-4 items-center',
+                $voteType->getJustify(),
+                'border-l-green-400 border-l-8 md:mr-8' => $voteType === App\Models\VoteType::YES,
+                'border-r-red-400 border-r-8 md:ml-8' => $voteType !== App\Models\VoteType::YES,
+            ])>
                 <div class="w-full">
-                    <small>
-                        Your argument:
-                    </small>
+                    <small>Your argument:</small>
 
                     <div class="grid gap-2">
                         <x-markdown-editor
                             wire:model="body"
-                            class="
-                                w-full border border-{{ $voteType->getColor() }}-200
-                                active:border-{{ $voteType->getColor() }}-400
-                                rounded
-                               "
+                            @class([
+                                'rounded w-full border',
+                                'border-green-200 active:border-green-200' => $voteType->getColor() === 'green',
+                                'border-red-200 active:border-red-200' => $voteType->getColor() === 'red',
+                           ])
                         />
+
                         @error('body')
-                        {{ $message }}
+                            {{ $message }}
                         @enderror
                     </div>
                 </div>
@@ -103,32 +82,26 @@
                 <div class="flex flex-col gap-2">
                     <button
                         type="submit"
-                        class="
-                            font-bold
-                            class='
-                            @if(empty($this->body))
-                             cursor-not-allowed
-                            @else
-                            cursor-pointer
-                            hover:bg-{{ $voteType->getColor() }}-600
-                            @endif
-                            py-2 px-4
-                            bg-{{ $voteType->getColor() }}-400
-                            text-white
-                            text-center
-                            rounded-full
-                        "
+                        @class([
+                            'font-bold py-2 px-4 text-white text-center rounded-full',
+                            'cursor-not-allowed' => empty($this->body),
+                            'cursor-pointer hover:bg-green-600' => ! empty($this->body) && $voteType->getColor() === 'green',
+                            'cursor-pointer hover:bg-red-600' => ! empty($this->body) && $voteType->getColor() === 'red',
+                            'bg-green-400' => $voteType->getColor() === 'green',
+                            'bg-red-400' => $voteType->getColor() === 'red',
+
+                        ])
                         wire:click="storeArgument"
-                    >Submit
+                    >
+                        Submit
                     </button>
 
-                    <button class="
-                        bg-gray-100
-                        hover:bg-gray-200
-                        py-2 px-4
-                        text-center
-                        rounded-full
-                    " wire:click="cancel">Cancel</button>
+                    <button
+                        class="bg-gray-100 hover:bg-gray-200 py-2 px-4 text-center rounded-full"
+                        wire:click="cancel"
+                    >
+                        Cancel
+                    </button>
                 </div>
             </div>
         </div>

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -33,7 +33,7 @@
             style="width: {{ $rfc->percentage_no }}%;"
 
             @if(! $hasVoted)
-                wire:click="vote('{{ \App\Models\VoteType::NO }}')"
+                wire:click="vote('{{ App\Models\VoteType::NO }}')"
             @endif
         >
             {{ $rfc->percentage_no }}%

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -7,28 +7,20 @@
 
     <div class="flex shadow-xl font-bold rounded-full overflow-hidden">
         <div
-            class="
-                    p-4 flex-grow text-left
-                    md:min-w-[15%]
-                    min-w-[20%]
-
-                    @if(! $hasVoted)
-                    hover:bg-green-600 hover:text-white cursor-pointer
-                    @endIf
-
-                    @if($voteType === \App\Models\VoteType::YES)
-                    bg-green-600 text-white
-                    @else
-                    bg-green-300 text-green-900
-                    @endif
-                "
+            @class([
+                'p-4 flex-grow text-left md:min-w-[15%] min-w-[20%]',
+                'hover:bg-green-600 hover:text-white cursor-pointer' => ! $hasVoted,
+                $voteType === App\Models\VoteType::YES ? 'bg-green-600 text-white' : 'bg-green-300 text-green-900',
+            ])
             style="width: {{ $rfc->percentage_yes }}%;"
+
             @if(! $hasVoted)
                 wire:click="vote('{{ \App\Models\VoteType::YES }}')"
             @endif
         >
             {{ $rfc->percentage_yes }}%
         </div>
+
         <div
             class="
                     p-4 flex-grow text-right

--- a/resources/views/livewire/vote-bar.blade.php
+++ b/resources/views/livewire/vote-bar.blade.php
@@ -10,9 +10,9 @@
         {{-- Left (green) bar --}}
         <div
             @class([
-                'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full text-white bg-agree-light transition-colors duration-300',
+                'py-1.5 lg:py-3 px-6 flex-grow text-left md:min-w-[15%] min-w-[20%] rounded-l-full bg-gradient-to-r from-agree to-agree-light text-white hover:opacity-100',
                 'cursor-not-allowed opacity-100' => $hasVoted,
-                'hover:bg-agree cursor-pointer opacity-80' => ! $hasVoted,
+                'hover:bg-green-600 cursor-pointer opacity-80 shadow-md hover:shadow-[0px_0px_7px_var(--color-agree-light)]' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_yes }}%;"
 
@@ -26,9 +26,9 @@
         {{-- Right (red) bar --}}
         <div
             @class([
-                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%] min-w-[20%] rounded-r-full bg-disagree-light text-white transition-colors duration-300',
-                'cursor-not-allowed' => $hasVoted,
-                'hover:bg-disagree cursor-pointer' => ! $hasVoted,
+                'py-1.5 lg:py-3 px-6 flex-grow text-right md:min-w-[15%]min-w-[20%] rounded-r-full bg-gradient-to-r from-disagree to-disagree-light text-white hover:opacity-100',
+                'cursor-not-allowed opacity-100' => $hasVoted,
+                'hover:bg-red-600 cursor-pointer opacity-80 shadow-md hover:shadow-[0px_0px_7px_var(--color-disagree-light)]' => ! $hasVoted,
             ])
             style="width: {{ $rfc->percentage_no }}%;"
 


### PR DESCRIPTION
I thought maybe it's a good idea to change the vote bar as well, nothing crazy, just simple styles:

## First example
![Screenshot 2023-08-18 at 12 46 40](https://github.com/brendt/rfc-vote/assets/35465417/ce98d7be-3e0c-4300-b423-d2198bad9cb1)

## Second example
![Screenshot 2023-08-18 at 12 53 09](https://github.com/brendt/rfc-vote/assets/35465417/2f3585ce-026e-4407-a644-14097341d349)

## Zoomed out look on new vote bar
![image](https://github.com/brendt/rfc-vote/assets/35465417/87b5a65b-0bdf-4c07-b404-a7c6dd03eeb6)

It matches to the styles that we have on RFCs cards on home page:
![image](https://github.com/brendt/rfc-vote/assets/35465417/7a15316c-51a2-47a7-a880-78c5d0318b35)

## Here is the hover effect
![Screen Recording 2023-08-18 at 12 59 29](https://github.com/brendt/rfc-vote/assets/35465417/a231594f-2bdb-459b-8f9d-c4d930be5391)

