### PR TITLE
Added tailwind custom main colors

### DIFF
--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -3,4 +3,6 @@
     --color-agree-light: #14b8a6;
     --color-disagree: #d11a66;
     --color-disagree-light: #f43f5e;
+    --color-main: #5b1497;
+    --color-main-light: #8c50c7;
 }

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -21,7 +21,7 @@
     $user = auth()->user();
 @endphp
 
-<nav class="bg-main bg-gradient-to-r from-main to-main-light z-10 px-4 py-4">
+<nav class="bg-main bg-gradient-to-r from-main to-main-light z-10 p-4">
     <div class="container flex justify-between text-white gap-4 items-center m-auto">
         <div class="text-lg md:text-xl font-bold">
             <a href="/">RFC Vote<span class="hidden md:inline"> {{ app()->isProduction() ? '' : ' (local)' }}</span></a>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -21,7 +21,7 @@
     $user = auth()->user();
 @endphp
 
-<nav class="bg-purple-800 bg-gradient-to-l from-purple-700 to-purple-900 z-10 px-4 py-5">
+<nav class="bg-main bg-gradient-to-r from-main to-main-light z-10 px-4 py-4">
     <div class="container flex justify-between text-white gap-4 items-center m-auto">
         <div class="text-lg md:text-xl font-bold">
             <a href="/">RFC Vote<span class="hidden md:inline"> {{ app()->isProduction() ? '' : ' (local)' }}</span></a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,8 @@ export default {
                 'agree-light': 'var(--color-agree-light)',
                 'disagree': 'var(--color-disagree)',
                 'disagree-light': 'var(--color-disagree-light)',
+                'main': 'var(--color-main)',
+                'main-light': 'var(--color-main-light)',
             },
         },
     },


### PR DESCRIPTION
1. Added 2 more CSS variables for main colors:

<img width="280" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/1e66fb8f-b4bc-49d2-abc1-e06ea2fa769e">

```css
--color-main: #5b1497;
--color-main-light: #8c50c7;
```

2. Added these 2 new purple colors to `tailwind.config.js` file.
3. Changed color of the navbar to match main colors:

<img width="1329" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/f22a7c41-846e-4172-9401-8edefa7d31dd">

Now, if we every want to change the **main (accent)** colors of the whole website, we can change it in `_variables.css` files in one place.

> I also changed the vertical padding of the navbar from `py-5` to `py-4` as it was still to thick and bootstrapish imo.