### PR TITLE
Verify email redesign

### DIFF
--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,39 +1,40 @@
-<x-guest-layout>
-    <x-authentication-card>
-        <x-slot name="logo">
-            <x-authentication-card-logo />
-        </x-slot>
+@component('layouts.base')
 
-        <div class="mb-4 text-sm text-gray-600">
-            {{ __('Before continuing, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
-        </div>
+    <div class="mx-auto max-w-[500px] mt-4 md:mt-12">
+        <x-form.wrapper
+            method="POST"
+            action="{{ route('verification.send') }}"
+            :heading="__('Verify Email Address')"
+        >
+            <p class="mb-5 text-gray-500">
+                {{ __('Before continuing, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
+            </p>
 
-        @if (session('status') == 'verification-link-sent')
-            <div class="mb-4 font-medium text-sm text-green-600">
-                {{ __('A new verification link has been sent to the email address you provided in your profile settings.') }}
+            @if (session('status') === 'verification-link-sent')
+                <x-success-message>
+                    {{ __('A new verification link has been sent to the email address you provided in your profile settings.') }}
+                </x-success-message>
+            @endif
+
+            <div class="flex justify-end gap-3 items-center mt-7">
+                <x-form.button type="submit">
+                    <x-icons.envelope class="w-6 h-6" />
+                    {{ __('Resend Verification Email') }}
+                </x-form.button>
+
+                <x-form.button
+                    type="button"
+                    class="!bg-transparent !text-red-900 hover:!bg-gray-100"
+                    onclick="document.getElementById('logout-form').submit()"
+                >
+                    {{ __('Logout') }}
+                </x-form.button>
             </div>
-        @endif
+        </x-form.wrapper>
+    </div>
 
-        <div class="mt-4 flex items-center justify-between">
-            <form method="POST" action="{{ route('verification.send') }}">
-                @csrf
+    <form method="POST" action="{{ route('logout') }}" class="hidden" id="logout-form">
+        @csrf
+    </form>
 
-                <div>
-                    <x-button type="submit">
-                        {{ __('Resend Verification Email') }}
-                    </x-button>
-                </div>
-            </form>
-
-            <div>
-                <form method="POST" action="{{ route('logout') }}" class="inline">
-                    @csrf
-
-                    <button type="submit" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ml-2">
-                        {{ __('Log Out') }}
-                    </button>
-                </form>
-            </div>
-        </div>
-    </x-authentication-card>
-</x-guest-layout>
+@endcomponent

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -16,7 +16,7 @@
                 </x-success-message>
             @endif
 
-            <div class="flex justify-end gap-3 items-center mt-7">
+            <div class="flex justify-end gap-2 items-center mt-7">
                 <x-form.button type="submit">
                     <x-icons.envelope class="w-6 h-6" />
                     {{ __('Resend Verification Email') }}
@@ -24,7 +24,7 @@
 
                 <x-form.button
                     type="button"
-                    class="!bg-transparent !text-red-900 hover:!bg-gray-100"
+                    class="!bg-transparent !text-gray-700 hover:!bg-gray-100"
                     onclick="document.getElementById('logout-form').submit()"
                 >
                     {{ __('Logout') }}

--- a/resources/views/components/buttons/main.blade.php
+++ b/resources/views/components/buttons/main.blade.php
@@ -1,7 +1,7 @@
 @php
     /**
      * @var Illuminate\View\ComponentAttributeBag $attributes
-     * @var string $slot
+     * @var Illuminate\View\ComponentSlot $slot
      */
 
     $styles = 'bg-purple-800 hover:bg-purple-900 inline-flex gap-3 px-4 py-2.5 px-4 transition-colors rounded-md font-bold text-white';

--- a/resources/views/components/form/button.blade.php
+++ b/resources/views/components/form/button.blade.php
@@ -1,8 +1,8 @@
 @php
     /**
-     * @var string $slot
+     * @var Illuminate\View\ComponentSlot $slot
      * @var Illuminate\View\ComponentAttributeBag $attributes
      */
 @endphp
 
-<x-buttons.main {{ $attributes->merge([]) }}>{{ $slot }}</x-buttons.main>
+<x-buttons.main {{ $attributes }}>{{ $slot }}</x-buttons.main>


### PR DESCRIPTION
Since we redesigned forms on:

- https://github.com/brendt/rfc-vote/pull/79
- https://github.com/brendt/rfc-vote/pull/85
- https://github.com/brendt/rfc-vote/pull/83
- https://github.com/brendt/rfc-vote/pull/94
- https://github.com/brendt/rfc-vote/pull/96

It makes sense to finish it off with the same redesign for verify email page

## Form before
<img width="646" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/d8a5558e-e3be-4df2-a8aa-fa99e93c1fc3">

## Form with message after
<img width="560" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/d7cc45ce-7b8a-49d8-88b4-83a26b9b8fd6">

## Form without message
<img width="614" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/e277c84e-28d4-429f-86f7-67cf8d2d0312">

This change reuses the same Blade component that we already have.