### PR TITLE
Argument card style fix

### DIFF
--- a/resources/views/components/argument-card/card-footer.blade.php
+++ b/resources/views/components/argument-card/card-footer.blade.php
@@ -39,9 +39,9 @@
             {{ __('voted') }}
 
             <b @class([
-                'tracking-wide uppercase',
-                'text-green-700' => $argument->vote_type->isYes(),
-                'text-red-700' => $argument->vote_type->isNo(),
+                'tracking-wide uppercase ml-0.5',
+                'text-agree' => $argument->vote_type->isYes(),
+                'text-disagree' => $argument->vote_type->isNo(),
             ])>
                 {{ $argument->vote_type->value }}
             </b>

--- a/resources/views/components/argument-card/card.blade.php
+++ b/resources/views/components/argument-card/card.blade.php
@@ -8,7 +8,7 @@
     $anchorLink = $argument->user->username . '-' . $argument->id;
 @endphp
 
-<div id="{{ $anchorLink }}" class="bg-white rounded-xl shadow-md w-full group/card px-6 pt-5 md:px-8 md:pt-7 flex gap-6 items-center relative">
+<div id="{{ $anchorLink }}" class="bg-white rounded-xl shadow-md w-full group/card pt-5 pl-4 pr-10 md:px-8 md:pt-7 flex gap-6 items-center relative">
     <x-argument-card.vote :argument="$argument" :user="$user" />
 
     @if (!$readonly && ($user?->can('edit', $argument) || $user?->can('delete', $argument)))

--- a/resources/views/components/argument-card/vote.blade.php
+++ b/resources/views/components/argument-card/vote.blade.php
@@ -11,6 +11,7 @@
             transition-colors
             py-3
             px-2
+            mb-5
             max-w-[50px]
             mx-auto
             text-center

--- a/resources/views/components/argument-card/vote.blade.php
+++ b/resources/views/components/argument-card/vote.blade.php
@@ -4,31 +4,16 @@
 
 <div
     class="
-            {{ $user?->can('vote', $argument) ?  "hover:border-gray-200 cursor-pointer" : "cursor-not-allowed" }}
-            flex
-            flex-col
-            gap-1
-            transition-colors
-            py-3
-            px-2
-            mb-5
-            max-w-[50px]
-            mx-auto
-            text-center
-            rounded-2xl
-            text-lg
-            border
-            border-transparent
-            bg-gray-100
-            box-content
-            @if ($argument->vote_type->isYes())
-                text-green-700
-                {{ $argument->user()->is($user) ? '' : 'hover:text-green-800' }}
-            @else
-                text-red-700
-                {{ $argument->user()->is($user) ? '' : 'hover:text-red-800' }}
-            @endif
-        "
+        {{ $user?->can('vote', $argument) ?  "hover:border-gray-200 cursor-pointer" : "cursor-not-allowed" }}
+        flex flex-col gap-1 transition-colors py-3 px-2 mb-5 max-w-[50px] mx-auto text-center rounded-2xl text-lg border border-transparent bg-gray-100 box-content
+        @if ($argument->vote_type->isYes())
+            text-green-700
+            {{ $argument->user()->is($user) ? '' : 'hover:text-green-800' }}
+        @else
+            text-red-700
+            {{ $argument->user()->is($user) ? '' : 'hover:text-red-800' }}
+        @endif
+    "
     wire:click="voteForArgument({{ $argument->id }})"
 >
     @if ($user?->hasVotedForArgument($argument))

--- a/resources/views/components/argument-card/vote.blade.php
+++ b/resources/views/components/argument-card/vote.blade.php
@@ -5,13 +5,17 @@
 <div
     class="
         {{ $user?->can('vote', $argument) ?  "hover:border-gray-200 cursor-pointer" : "cursor-not-allowed" }}
-        flex flex-col gap-1 transition-colors py-3 px-2 mb-5 max-w-[50px] mx-auto text-center rounded-2xl text-lg border border-transparent bg-gray-100 box-content
+        flex flex-col gap-1 transition-colors py-3 px-2 mb-5 max-w-[50px] mx-auto text-center rounded-2xl text-lg border border-transparent box-content
         @if ($argument->vote_type->isYes())
-            text-green-700
-            {{ $argument->user()->is($user) ? '' : 'hover:text-green-800' }}
+            text-agree
+            bg-green-50
+            border-green-300
+            {{ $argument->user()->is($user) ? '' : 'hover:border-agree-light hover:text-agree-dark' }}
         @else
-            text-red-700
-            {{ $argument->user()->is($user) ? '' : 'hover:text-red-800' }}
+            text-disagree
+            bg-red-50
+            border-red-300
+            {{ $argument->user()->is($user) ? '' : 'hover:border-disagree-light hover:text-disagree-dark' }}
         @endif
     "
     wire:click="voteForArgument({{ $argument->id }})"


### PR DESCRIPTION
Fixed styles on argument card when it was one with 1 line of text.

### Argument before changes (desktop)
![image](https://github.com/brendt/rfc-vote/assets/35465417/37bdc399-7a7f-4553-a90e-8ed1d0970c37)

### Argument before changes (mobile)
![image](https://github.com/brendt/rfc-vote/assets/35465417/89030255-78e9-4733-b27a-7e86b16b72ed)

### Argument after changes (desktop)
![image](https://github.com/brendt/rfc-vote/assets/35465417/0f3e7c97-f374-4444-993f-d2c7b456ff29)

### Argument after changes (mobile)
![image](https://github.com/brendt/rfc-vote/assets/35465417/f604b1b1-7578-482f-8147-264f6b767aa1)

Also added the slightest green and red background to vote buttons to make them more stand out:
![Screenshot 2023-08-20 at 13 33 23](https://github.com/brendt/rfc-vote/assets/35465417/0c113bfd-1192-4d18-9f82-1258f885a6fc)
