### PR TITLE
Admin arguments redesign

### DIFF
--- a/resources/views/components/buttons/main-small-solid.blade.php
+++ b/resources/views/components/buttons/main-small-solid.blade.php
@@ -1,0 +1,18 @@
+@php
+    /**
+     * @var Illuminate\View\ComponentAttributeBag $attributes
+     * @var Illuminate\View\ComponentSlot $slot
+     */
+
+    $styles = 'bg-none hover:bg-purple-50 hover:text-gray-700 hover:border-gray-600 inline-flex items-center justify-center gap-2 px-2 py-1 transition-colors rounded-md border border-main-light font-bold text-sm cursor-pointer text-main-dark';
+@endphp
+
+@if ($attributes->has('href'))
+    <a {{ $attributes->merge(['class' => $styles]) }}>
+        {{ $slot }}
+    </a>
+@else
+    <button {{ $attributes->merge(['class' => $styles]) }}>
+        {{ $slot }}
+    </button>
+@endif

--- a/resources/views/components/buttons/main-small.blade.php
+++ b/resources/views/components/buttons/main-small.blade.php
@@ -1,7 +1,7 @@
 @php
     /**
      * @var Illuminate\View\ComponentAttributeBag $attributes
-     * @var string $slot
+     * @var Illuminate\View\ComponentSlot $slot
      */
 
     $styles = 'bg-purple-800 hover:bg-purple-900 inline-flex items-center justify-center gap-3 px-3 py-1 transition-colors rounded-md font-bold text-white text-sm cursor-pointer';

--- a/resources/views/components/icons/plus.blade.php
+++ b/resources/views/components/icons/plus.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" {{ $attributes->merge(['stroke-width' => '1.5']) }}>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+</svg>

--- a/resources/views/rfc-admin.blade.php
+++ b/resources/views/rfc-admin.blade.php
@@ -1,7 +1,8 @@
 @component('layouts.base')
     <div class="grid gap-4 px-4">
         <div class="p-4 flex justify-end bg-white">
-            <a href="{{ action([\App\Http\Controllers\RfcCreateController::class, 'create']) }}"
+            <a
+                href="{{ action([\App\Http\Controllers\RfcCreateController::class, 'create']) }}"
                class="bg-green-100 border border-green-500 text-green-500 hover:bg-green-500 hover:text-white p-2 py-1 font-bold rounded text-center"
             >New</a>
         </div>
@@ -29,21 +30,13 @@
                             <div
                                 class="border-gray-700 border flex font-bold text-sm min-w-[20%]">
                                 <div
-                                    class="
-                                    p-1 px-4 flex-grow text-left border-r border-gray-700
-                                    min-w-[30%]
-                                    bg-green-300 text-green-900
-                                "
+                                    class="p-1 px-4 flex-grow text-left border-r border-gray-700 min-w-[30%] bg-green-300 text-green-900"
                                     style="width: {{ $rfc->percentage_yes }}%;"
                                 >
                                     {{ $rfc->percentage_yes }}%
                                 </div>
                                 <div
-                                    class="
-                            p-1 px-4 flex-grow text-right border-gray-700
-                            min-w-[30%]
-                            bg-red-300 text-red-900
-                        "
+                                    class="p-1 px-4 flex-grow text-right border-gray-700 min-w-[30%] bg-red-300 text-red-900"
                                     style="width: {{ $rfc->percentage_no }}%;"
                                 >
                                     {{ $rfc->percentage_no }}%

--- a/resources/views/rfc-admin.blade.php
+++ b/resources/views/rfc-admin.blade.php
@@ -25,47 +25,47 @@
                         {{ $rfc->description }}
                     </div>
 
-                    <div class="col-span-6 flex justify-end gap-1 items-baseline text-sm">
+                    <div class="col-span-6 flex justify-end gap-2 items-center text-sm">
                         @if($rfc->arguments->isNotEmpty())
-                            <div
-                                class="border-gray-700 border flex font-bold text-sm min-w-[20%]">
+                            <div class="flex font-bold text-sm min-w-[20%] text-white rounded-md">
                                 <div
-                                    class="p-1 px-4 flex-grow text-left border-r border-gray-700 min-w-[30%] bg-green-300 text-green-900"
+                                    class="rounded-l-md pl-2 py-[6px] items-center text-left border-r border-gray-700 min-w-[30%] bg-agree text-xs"
                                     style="width: {{ $rfc->percentage_yes }}%;"
                                 >
-                                    {{ $rfc->percentage_yes }}%
+                                    {{ $rfc->percentage_yes }}<small>%</small>
                                 </div>
+
+                                <div class="bg-white w-[1px]"></div>
+
                                 <div
-                                    class="p-1 px-4 flex-grow text-right border-gray-700 min-w-[30%] bg-red-300 text-red-900"
+                                    class="rounded-r-md pr-2 py-[6px] items-center text-right border-gray-700 min-w-[30%] bg-disagree text-xs"
                                     style="width: {{ $rfc->percentage_no }}%;"
                                 >
-                                    {{ $rfc->percentage_no }}%
+                                    {{ $rfc->percentage_no }}<small>%</small>
                                 </div>
                             </div>
                         @endif
 
-                        <a
-                            href="{{ action([\App\Http\Controllers\RfcEditController::class, 'edit'], $rfc) }}"
-                            class="bg-blue-100 border border-blue-500 text-blue-500 hover:bg-blue-500 hover:text-white p-1 px-3 py-1 font-bold rounded text-center"
-                        >Edit</a>
+                        <x-buttons.main-small-solid href="{{ action([App\Http\Controllers\RfcEditController::class, 'edit'], $rfc) }}">
+                            <x-icons.pen class="w-4 h-4" />
+                            Edit
+                        </x-buttons.main-small-solid>
 
                         @if($rfc->published_at === null)
                             <form action="{{ action(\App\Http\Controllers\PublishRfcController::class, $rfc) }}" method="post">
                                 @csrf()
-                                <button
-                                    type="submit"
-                                    class="bg-blue-100 border border-blue-500 text-blue-500 hover:bg-blue-500 hover:text-white p-1 px-3 py-1 font-bold rounded text-center"
-                                >Publish</button>
+                                <x-buttons.main-small-solid type="submit">
+                                    Publish
+                                </x-buttons.main-small-solid>
                             </form>
                         @endif
 
                         @if($rfc->ends_at === null)
                             <form action="{{ action(\App\Http\Controllers\EndRfcController::class, $rfc) }}" method="post">
                                 @csrf()
-                                <button
-                                    type="submit"
-                                    class="bg-gray-100 border border-gray-500 text-gray-500 hover:bg-gray-500 hover:text-white p-1 px-3 py-1 font-bold rounded text-center"
-                                >End</button>
+                                <x-buttons.main-small-solid type="submit" class="!border-disagree !text-disagree">
+                                    End
+                                </x-buttons.main-small-solid>
                             </form>
                         @endif
                     </div>

--- a/resources/views/rfc-admin.blade.php
+++ b/resources/views/rfc-admin.blade.php
@@ -1,86 +1,89 @@
 @component('layouts.base')
-    <div class="grid gap-4 px-4">
-        <div class="p-4 flex justify-end bg-white">
-            <a
-                href="{{ action([App\Http\Controllers\RfcCreateController::class, 'create']) }}"
-               class="bg-green-100 border border-green-500 text-green-500 hover:bg-green-500 hover:text-white p-2 py-1 font-bold rounded text-center"
-            >New</a>
-        </div>
+    <div class="container mx-auto">
+        <div class="grid gap-4 px-4">
+            <div class="grid gap-2 divide-y divide-gray-300">
+                @foreach($rfcs as $rfc)
+                    <div class="grid grid-cols-6 lg:grid-cols-12 p-4 gap-4 items-center">
+                        <div class="col-span-6 lg:col-span-2 space-y-1">
+                            <h2 class="font-bold">
+                                {{ $rfc->title }}
+                            </h2>
 
-        <div class="grid gap-2 divide-y divide-gray-300">
-            @foreach($rfcs as $rfc)
-                <div class="grid grid-cols-6 lg:grid-cols-12 p-4 gap-4 items-center">
-                    <div class="col-span-6 lg:col-span-2 space-y-1">
-                        <h2 class="font-bold">
-                            {{ $rfc->title }}
-                        </h2>
-
-                        <div class="flex text-gray-500 text-sm">
-                            {{ $rfc->published_at?->format('Y-m-d') }}
-                            <span>&nbsp;—&nbsp;</span> {{ $rfc->ends_at?->format('Y-m-d') ?? 'unknown' }}
-                        </div>
-
-                        <div>
-                            <div @class([
-                                'inline-flex gap-2 items-baseline border-t border rounded-full px-2',
-                                $rfc->isActive() ? 'border-agree-light bg-green-50' : 'border-disagree-light bg-red-50',
-                            ])>
-                                <div class="w-3 h-3 rounded-full {{ $rfc->isActive() ? 'bg-agree-light' : 'bg-disagree-light' }}"></div>
-                                <span class="text-sm">{{ $rfc->isActive() ? 'Active' : 'Not active' }}</span>
+                            <div class="flex text-gray-500 text-sm">
+                                {{ $rfc->published_at?->format('Y-m-d') }}
+                                <span>&nbsp;—&nbsp;</span> {{ $rfc->ends_at?->format('Y-m-d') ?? 'unknown' }}
                             </div>
-                        </div>
-                    </div>
 
-                    <div class="col-span-6">
-                        {{ $rfc->description }}
-                    </div>
-
-                    <div class="col-span-6 md:col-span-4 flex gap-3 items-center text-sm">
-                        @if($rfc->arguments->isNotEmpty())
-                            <div class="flex font-bold text-sm w-full text-white rounded-md">
-                                <div
-                                    class="rounded-l-md pl-2 py-[6px] items-center text-left border-r border-gray-700 min-w-[30%] bg-agree text-xs"
-                                    style="width: {{ $rfc->percentage_yes }}%;"
-                                >
-                                    {{ $rfc->percentage_yes }}<small>%</small>
-                                </div>
-
-                                <div class="bg-white w-[1px]"></div>
-
-                                <div
-                                    class="rounded-r-md pr-2 py-[6px] items-center text-right border-gray-700 min-w-[30%] bg-disagree text-xs"
-                                    style="width: {{ $rfc->percentage_no }}%;"
-                                >
-                                    {{ $rfc->percentage_no }}<small>%</small>
+                            <div>
+                                <div @class([
+                                    'inline-flex gap-2 items-baseline border-t border rounded-full px-2',
+                                    $rfc->isActive() ? 'border-agree-light bg-green-50' : 'border-disagree-light bg-red-50',
+                                ])>
+                                    <div class="w-3 h-3 rounded-full {{ $rfc->isActive() ? 'bg-agree-light' : 'bg-disagree-light' }}"></div>
+                                    <span class="text-sm">{{ $rfc->isActive() ? 'Active' : 'Not active' }}</span>
                                 </div>
                             </div>
-                        @endif
+                        </div>
 
-                        <x-buttons.main-small-solid href="{{ action([App\Http\Controllers\RfcEditController::class, 'edit'], $rfc) }}">
-                            <x-icons.pen class="w-4 h-4" />
-                            Edit
-                        </x-buttons.main-small-solid>
+                        <div class="col-span-6">
+                            {{ $rfc->description }}
+                        </div>
 
-                        @if($rfc->published_at === null)
-                            <form action="{{ action(App\Http\Controllers\PublishRfcController::class, $rfc) }}" method="post">
-                                @csrf()
-                                <x-buttons.main-small-solid type="submit">
-                                    Publish
-                                </x-buttons.main-small-solid>
-                            </form>
-                        @endif
+                        <div class="col-span-6 md:col-span-4 flex gap-3 items-center text-sm">
+                            @if($rfc->arguments->isNotEmpty())
+                                <div class="flex font-bold text-sm w-full text-white rounded-md">
+                                    <div
+                                        class="rounded-l-md pl-2 py-[6px] items-center text-left border-r border-gray-700 min-w-[30%] bg-agree text-xs"
+                                        style="width: {{ $rfc->percentage_yes }}%;"
+                                    >
+                                        {{ $rfc->percentage_yes }}<small>%</small>
+                                    </div>
 
-                        @if($rfc->ends_at === null)
-                            <form action="{{ action(App\Http\Controllers\EndRfcController::class, $rfc) }}" method="post">
-                                @csrf()
-                                <x-buttons.main-small-solid type="submit" class="!border-disagree !text-disagree">
-                                    End
-                                </x-buttons.main-small-solid>
-                            </form>
-                        @endif
+                                    <div class="bg-white w-[1px]"></div>
+
+                                    <div
+                                        class="rounded-r-md pr-2 py-[6px] items-center text-right border-gray-700 min-w-[30%] bg-disagree text-xs"
+                                        style="width: {{ $rfc->percentage_no }}%;"
+                                    >
+                                        {{ $rfc->percentage_no }}<small>%</small>
+                                    </div>
+                                </div>
+                            @endif
+
+                            <x-buttons.main-small-solid href="{{ action([App\Http\Controllers\RfcEditController::class, 'edit'], $rfc) }}">
+                                <x-icons.pen class="w-4 h-4" />
+                                Edit
+                            </x-buttons.main-small-solid>
+
+                            @if($rfc->published_at === null)
+                                <form action="{{ action(App\Http\Controllers\PublishRfcController::class, $rfc) }}" method="post">
+                                    @csrf()
+                                    <x-buttons.main-small-solid type="submit">
+                                        Publish
+                                    </x-buttons.main-small-solid>
+                                </form>
+                            @endif
+
+                            @if($rfc->ends_at === null)
+                                <form action="{{ action(App\Http\Controllers\EndRfcController::class, $rfc) }}" method="post">
+                                    @csrf()
+                                    <x-buttons.main-small-solid type="submit" class="!border-disagree !text-disagree">
+                                        End
+                                    </x-buttons.main-small-solid>
+                                </form>
+                            @endif
+                        </div>
                     </div>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
         </div>
     </div>
+
+    <x-buttons.main
+        href="{{ action([App\Http\Controllers\RfcCreateController::class, 'create']) }}"
+        class="fixed right-4 md:right-6 bottom-4 md:bottom-6 border-2 border-white"
+    >
+        <x-icons.plus class="w-5 h-5 drop-shadow-[1px_1px_0_white]" />
+        New RFC
+    </x-buttons.main>
 @endcomponent

--- a/resources/views/rfc-admin.blade.php
+++ b/resources/views/rfc-admin.blade.php
@@ -7,27 +7,37 @@
             >New</a>
         </div>
 
-        <div class="grid gap-2">
+        <div class="grid gap-2 divide-y divide-gray-300">
             @foreach($rfcs as $rfc)
-                <div
-                    class="grid grid-cols-12 p-4 gap-4 items-center {{ $rfc->isActive() ? 'bg-white border-l-8 border-blue-800' : 'bg-gray-50' }}">
-                    <div class="grid col-span-2">
-                        <span class="font-bold">
+                <div class="grid grid-cols-12 p-4 gap-4 items-center">
+                    <div class="grid col-span-2 gap-1">
+                        <h2 class="font-bold">
                             {{ $rfc->title }}
-                        </span>
-                        <div class="flex">
+                        </h2>
+
+                        <div class="flex text-gray-500 text-sm">
                             {{ $rfc->published_at?->format('Y-m-d') }}
-                            <span>&nbsp;—&nbsp;</span> {{ $rfc->ends_at?->format('Y-m-d') }}
+                            <span>&nbsp;—&nbsp;</span> {{ $rfc->ends_at?->format('Y-m-d') ?? 'unknown' }}
+                        </div>
+
+                        <div>
+                            <div @class([
+                                'inline-flex gap-2 items-baseline border-t border rounded-full px-2',
+                                $rfc->isActive() ? 'border-agree-light bg-green-50' : 'border-disagree-light bg-red-50',
+                            ])>
+                                <div class="w-3 h-3 rounded-full {{ $rfc->isActive() ? 'bg-agree-light' : 'bg-disagree-light' }}"></div>
+                                <span class="text-sm">{{ $rfc->isActive() ? 'Active' : 'Not active' }}</span>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="col-span-4">
+                    <div class="col-span-6">
                         {{ $rfc->description }}
                     </div>
 
-                    <div class="col-span-6 flex justify-end gap-2 items-center text-sm">
+                    <div class="col-span-4 flex justify-end gap-3 items-center text-sm">
                         @if($rfc->arguments->isNotEmpty())
-                            <div class="flex font-bold text-sm min-w-[20%] text-white rounded-md">
+                            <div class="flex font-bold text-sm w-full text-white rounded-md">
                                 <div
                                     class="rounded-l-md pl-2 py-[6px] items-center text-left border-r border-gray-700 min-w-[30%] bg-agree text-xs"
                                     style="width: {{ $rfc->percentage_yes }}%;"

--- a/resources/views/rfc-admin.blade.php
+++ b/resources/views/rfc-admin.blade.php
@@ -2,15 +2,15 @@
     <div class="grid gap-4 px-4">
         <div class="p-4 flex justify-end bg-white">
             <a
-                href="{{ action([\App\Http\Controllers\RfcCreateController::class, 'create']) }}"
+                href="{{ action([App\Http\Controllers\RfcCreateController::class, 'create']) }}"
                class="bg-green-100 border border-green-500 text-green-500 hover:bg-green-500 hover:text-white p-2 py-1 font-bold rounded text-center"
             >New</a>
         </div>
 
         <div class="grid gap-2 divide-y divide-gray-300">
             @foreach($rfcs as $rfc)
-                <div class="grid grid-cols-12 p-4 gap-4 items-center">
-                    <div class="grid col-span-2 gap-1">
+                <div class="grid grid-cols-6 lg:grid-cols-12 p-4 gap-4 items-center">
+                    <div class="col-span-6 lg:col-span-2 space-y-1">
                         <h2 class="font-bold">
                             {{ $rfc->title }}
                         </h2>
@@ -35,7 +35,7 @@
                         {{ $rfc->description }}
                     </div>
 
-                    <div class="col-span-4 flex justify-end gap-3 items-center text-sm">
+                    <div class="col-span-6 md:col-span-4 flex gap-3 items-center text-sm">
                         @if($rfc->arguments->isNotEmpty())
                             <div class="flex font-bold text-sm w-full text-white rounded-md">
                                 <div
@@ -62,7 +62,7 @@
                         </x-buttons.main-small-solid>
 
                         @if($rfc->published_at === null)
-                            <form action="{{ action(\App\Http\Controllers\PublishRfcController::class, $rfc) }}" method="post">
+                            <form action="{{ action(App\Http\Controllers\PublishRfcController::class, $rfc) }}" method="post">
                                 @csrf()
                                 <x-buttons.main-small-solid type="submit">
                                     Publish
@@ -71,7 +71,7 @@
                         @endif
 
                         @if($rfc->ends_at === null)
-                            <form action="{{ action(\App\Http\Controllers\EndRfcController::class, $rfc) }}" method="post">
+                            <form action="{{ action(App\Http\Controllers\EndRfcController::class, $rfc) }}" method="post">
                                 @csrf()
                                 <x-buttons.main-small-solid type="submit" class="!border-disagree !text-disagree">
                                     End


### PR DESCRIPTION
Styled the RFCs page in admin panel

<img width="1456" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/a07b990d-9aaa-47d7-b7dd-8ece7a95bb80">

Also added a mobile version because this page was broken on mobile:

![image](https://github.com/brendt/rfc-vote/assets/35465417/ce626355-a045-48e3-aff9-98c621d0f71c)

Also moved "New RFC" button to the bottom right corner. It has a fixed position:

![image](https://github.com/brendt/rfc-vote/assets/35465417/c00dd4b3-e149-457e-a59b-c4fbff85e632)

### Admin page before
![image](https://github.com/brendt/rfc-vote/assets/35465417/6886c0ab-c332-4586-b684-54b3d8b1f1d5)
