### PR TITLE
Added styles to user flair on argument card

### DIFF
--- a/resources/views/components/argument-card/card-footer.blade.php
+++ b/resources/views/components/argument-card/card-footer.blade.php
@@ -21,6 +21,16 @@
         @endif
 
         <small class="flex items-center gap-1">
+            @if($argumentUser?->flair)
+                <span
+                    aria-label="User role"
+                    class="text-xs border px-3 py-0.5 rounded-full mr-1.5"
+                    title="This user is {{ Str::title($argumentUser->flair) }}"
+                >
+                    {{ Str::title($argumentUser->flair) }}
+                </span>
+            @endif
+
             @if ($argumentUser?->getAvatarUrl())
                 <a
                     href="{{ action(App\Http\Controllers\PublicProfileController::class, $argumentUser) }}"
@@ -33,10 +43,6 @@
                     />
 
                     <div class="group-hover/username:underline">{{ \Illuminate\Support\Str::limit($argumentUser->username, 18) }}</div>
-
-                    @if($user->flair)
-                        <x-tag class="text-xs text-white" style="background-color: {{ $user->flair_color }}">{{ $user->flair }}</x-tag>
-                    @endif
                 </a>
             @endif
 


### PR DESCRIPTION
Added styles to user flair 😄

<img width="281" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/991d99f4-e276-46bf-998f-2e2cd3974584">

Temporarily, I'm added `Str::title()` to user flair, you can replace this with a proper flair title if you abstract it into an enum or database table. It's up to you.

Related #147 