### PR TITLE
exclude the current RFC from the additional rfcs to prevent duplication

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -46,6 +46,7 @@ final readonly class HomeController
         if (! $row) {
             return null;
         }
+
         return Argument::find($row->argument_id);
     }
 }


### PR DESCRIPTION
this PR fixes a bug related to "Check another RFCs feature" by excluding the current RFC from the results to prevent duplications.