### PR TITLE
Fixed form padding on mobile

### DIFF
--- a/resources/views/components/form/wrapper.blade.php
+++ b/resources/views/components/form/wrapper.blade.php
@@ -6,7 +6,7 @@
      */
 @endphp
 
-<form {{ $attributes->merge(['class' => 'bg-white p-8 rounded-lg shadow-md']) }}>
+<form {{ $attributes->merge(['class' => 'bg-white mx-3 md:mx-0 p-8 rounded-lg shadow-md']) }}>
     @csrf
 
     @isset($heading)


### PR DESCRIPTION
Very tiny fix of forms on mobile view. There was no horizontal margin, looked ugly when I've checked the site from the iPhone. You can see on the screenshots around the form card before and after:

![Screenshot 2023-08-22 at 16-36-49 RFC Vote](https://github.com/brendt/rfc-vote/assets/35465417/43d25a50-732e-4967-b7d7-4ea2f57d717f)

It applies to almost all forms