### PR TITLE
Refactored the site footer

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -1,5 +1,5 @@
 @component('layouts.base')
-    <div class="container max-w-[600px] mx-auto prose px-4">
+    <div class="container max-w-[600px] mx-auto prose px-4 mb-10">
 <x-markdown>
 ## Shaping PHP, together
 

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
 @component('layouts.base')
-    <div class="max-w-lg m-auto mt-12">
+    <div class="max-w-lg m-auto my-12">
         <x-form.wrapper
             method="POST"
             action="{{ route('password.email') }}"

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 @component('layouts.base')
-    <div class="max-w-lg m-auto mt-12">
+    <div class="max-w-lg m-auto my-12">
         <x-form.wrapper
             method="POST"
             action="{{ route('password.update') }}"

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,6 +1,6 @@
 @component('layouts.base')
 
-    <div class="mx-auto max-w-[500px] mt-4 md:mt-12">
+    <div class="mx-auto max-w-[500px] my-4 md:my-12">
         <x-form.wrapper
             method="POST"
             action="{{ route('verification.send') }}"

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,22 @@
+<div class="
+    p-8 text-white flex justify-center md:gap-6 gap-4 flex-col bg-purple-800
+    bg-gradient-to-br from-purple-700 to-purple-900
+">
+    <div class="flex font-bold flex-wrap md:flex-nowrap gap-4 flex-1 justify-center">
+        <span class="w-full md:w-auto">This project is open source, you can help out.</span>
+        <div class="w-full md:w-auto">
+            <a href="https://github.com/brendt/rfc-vote" class="bg-white px-4 p-2 text-purple-600 font-bold rounded hover:bg-purple-300 hover:text-purple-800">Check out the repository</a>
+        </div>
+    </div>
+
+    <div class="md:text-center">
+        <p>
+            Special thanks to <a class="text-purple-200 underline hover:no-underline" href="https://github.com/brendt/rfc-vote/graphs/contributors">numerous contributors</a> for sending PRs, and <a href="https://tighten.com/" class="text-purple-200 underline hover:no-underline">Tighten</a> for helping out with the design!
+        </p>
+    </div>
+
+    <div class="flex justify-center gap-2 text-sm">
+        <a href="/feed" class="underline hover:no-underline text-purple-200">RSS</a>
+        <a href="https://github.com/brendt/rfc-vote" class="underline hover:no-underline text-purple-200">GitHub</a>
+    </div>
+</div>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,17 +1,24 @@
 <div class="
     p-8 text-white flex justify-center md:gap-6 gap-4 flex-col bg-purple-800
-    bg-gradient-to-br from-purple-700 to-purple-900
+    bg-gradient-to-br from-main to-main-dark
 ">
     <div class="flex font-bold flex-wrap md:flex-nowrap gap-4 flex-1 justify-center">
-        <span class="w-full md:w-auto">This project is open source, you can help out.</span>
+        <span class="w-full md:w-auto">
+            {{ __('This project is open source, you can help out') }}
+        </span>
         <div class="w-full md:w-auto">
-            <a href="https://github.com/brendt/rfc-vote" class="bg-white px-4 p-2 text-purple-600 font-bold rounded hover:bg-purple-300 hover:text-purple-800">Check out the repository</a>
+            <a
+                href="https://github.com/brendt/rfc-vote"
+                class="bg-white px-3 py-2 text-main font-bold rounded hover:bg-purple-100 hover:text-main-dark"
+            >
+                {{ __('Check out the repository') }}
+            </a>
         </div>
     </div>
 
     <div class="md:text-center">
         <p>
-            Special thanks to <a class="text-purple-200 underline hover:no-underline" href="https://github.com/brendt/rfc-vote/graphs/contributors">numerous contributors</a> for sending PRs, and <a href="https://tighten.com/" class="text-purple-200 underline hover:no-underline">Tighten</a> for helping out with the design!
+            Special thanks to <a class="text-purple-200 underline hover:no-underline" href="https://github.com/brendt/rfc-vote/graphs/contributors">numerous contributors</a> for sending PRs and helping out!
         </p>
     </div>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,9 +1,9 @@
 @component('layouts.base')
-    <div class="container mx-auto px-4 mt-4 md:mt-12 max-w-[1200px]">
-        <x-email-optin-banner :user="auth()->user()"/>
-    </div>
+    <div class="container max-w-[1200px] mx-auto px-4 grid gap-4 my-10">
+        <div class="px-4 max-w-[1200px]">
+            <x-email-optin-banner :user="auth()->user()"/>
+        </div>
 
-    <div class="container max-w-[1200px] mx-auto px-4 grid gap-4 mt-4 md:mt-8">
         <x-home.title>
             {{ __('Open RFCs') }}
         </x-home.title>
@@ -67,10 +67,8 @@
                 </x-card-link>
             @endforeach
         </div>
-    </div>
 
-    @if($argumentOfTheDay)
-        <div class="container max-w-[1200px] mx-auto px-4 grid mt-4 md:mt-8 gap-4">
+        @if($argumentOfTheDay)
             <x-home.title>
                 {{ __('Argument of the Day') }}
             </x-home.title>
@@ -81,7 +79,7 @@
                 :argument="$argumentOfTheDay"
                 :readonly="true"
             />
-        </div>
-    @endif
+        @endif
+    </div>
 
 @endcomponent

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -129,30 +129,7 @@
     </div>
 @endif
 
-<div class="
-    p-8 text-white mt-8
-    flex justify-center md:gap-6 gap-4 flex-col
-    bg-purple-800
-    bg-gradient-to-br from-purple-700 to-purple-900
-">
-    <div class="flex font-bold flex-wrap md:flex-nowrap gap-4 flex-1 justify-center">
-        <span class="w-full md:w-auto">This project is open source, you can help out.</span>
-        <div class="w-full md:w-auto">
-            <a href="https://github.com/brendt/rfc-vote" class="bg-white px-4 p-2 text-purple-600 font-bold rounded hover:bg-purple-300 hover:text-purple-800">Check out the repository</a>
-        </div>
-    </div>
-
-    <div class="md:text-center">
-        <p>
-            Special thanks to <a class="text-purple-200 underline hover:no-underline" href="https://github.com/brendt/rfc-vote/graphs/contributors">numerous contributors</a> for sending PRs, and <a href="https://tighten.com/" class="text-purple-200 underline hover:no-underline">Tighten</a> for helping out with the design!
-        </p>
-    </div>
-
-    <div class="flex justify-center gap-2 text-sm">
-        <a href="/feed" class="underline hover:no-underline text-purple-200">RSS</a>
-        <a href="https://github.com/brendt/rfc-vote" class="underline hover:no-underline text-purple-200">GitHub</a>
-    </div>
-</div>
+<x-footer />
 
 @livewireScripts
 </body>

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -1,6 +1,6 @@
 @component('layouts.base')
 
-    <div class="mx-auto max-w-[500px] mt-4 md:mt-12">
+    <div class="mx-auto max-w-[500px] my-4 md:my-12">
         <x-form.wrapper
             :heading="__('Login to your account')"
             method="{{ route('login') }}"

--- a/resources/views/profile-form.blade.php
+++ b/resources/views/profile-form.blade.php
@@ -1,5 +1,5 @@
 @component('layouts.base')
-    <div class="grid mx-auto container max-w-[800px] px-4 gap-6 mt-4 md:mt-12 mb-8">
+    <div class="grid mx-auto container max-w-[800px] px-4 gap-6 my-4 md:my-12">
         <x-form.wrapper
             action="{{ action([App\Http\Controllers\ProfileController::class, 'update']) }}"
             method="post"

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -1,6 +1,6 @@
 @component('layouts.base')
 
-    <div class="mx-auto max-w-[500px] mt-4 md:mt-12">
+    <div class="mx-auto max-w-[500px] my-4 md:my-12">
         <x-form.wrapper
             method="{{ route('register') }}"
             method="post"


### PR DESCRIPTION
There are no visual change for the footer, I've just extracted it into a separate component and removed margin top from it. Because of the absence of margin, I needed to add this margin on all pages so that pages do not glue to the footer.

This PR is more of a preparation for a footer redesign PR. Here is how it looks with this PR:

<img width="1241" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/94c09453-7ab6-4568-b0a9-d0d592cc690c">

I also removed special thanks to Tighten, but I get put it back if you want. I just think that instead of listing all contributors in the footer, we can make a separate section on home page and fetch them from github, and show them like in small bubbles or something. But that's a discussion for a different issue.