### PR TITLE
💄 Additional style fixes for default emails

### DIFF
--- a/resources/views/emails/email-verification.blade.php
+++ b/resources/views/emails/email-verification.blade.php
@@ -13,7 +13,7 @@
 <h1>Verify your Email</h1>
 <p>You have requested to change your email address. Please click the button below to verify your new email:</p>
 
-@component('mail::button', ['url' => $verificationLink, 'color' => 'purple'])
+@component('mail::button', ['url' => $verificationLink])
 Verify email
 @endcomponent
 

--- a/resources/views/emails/new-rfc.blade.php
+++ b/resources/views/emails/new-rfc.blade.php
@@ -14,7 +14,7 @@
 <h1>New RFC is out!</h1>
 <p>Hi <b>{{ $user->name }}</b>! There's a new RFC in town <b>"{{ $rfc->title }}"</b>! Check it out, vote, and share your arguments!</p>
 
-@component('mail::button', ['url' => action(App\Http\Controllers\RfcDetailController::class, $rfc), 'color' => 'purple'])
+@component('mail::button', ['url' => action(App\Http\Controllers\RfcDetailController::class, $rfc)])
     Go to the RFC
 @endcomponent
 

--- a/resources/views/emails/team-invitation.blade.php
+++ b/resources/views/emails/team-invitation.blade.php
@@ -9,7 +9,7 @@
 @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::registration()))
 {{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:') }}
 
-@component('mail::button', ['url' => route('register'), 'color' => 'purple'])
+@component('mail::button', ['url' => route('register')])
 {{ __('Create Account') }}
 @endcomponent
 

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -21,7 +21,6 @@
 {{-- Footer --}}
 <x-slot:footer>
 <x-mail::footer>
-© {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
 </x-mail::footer>
 </x-slot:footer>
 </x-mail::layout>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -232,14 +232,6 @@ img {
 
 .button-blue,
 .button-primary {
-    background-color: #2d3748;
-    border-bottom: 8px solid #2d3748;
-    border-left: 18px solid #2d3748;
-    border-right: 18px solid #2d3748;
-    border-top: 8px solid #2d3748;
-}
-
-.button-purple {
     background-color: #763dac;
     border-bottom: 12px solid #763dac;
     border-left: 35px solid #763dac;

--- a/resources/views/vendor/mail/text/message.blade.php
+++ b/resources/views/vendor/mail/text/message.blade.php
@@ -21,7 +21,6 @@
     {{-- Footer --}}
     <x-slot:footer>
         <x-mail::footer>
-            © {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
         </x-mail::footer>
     </x-slot:footer>
 </x-mail::layout>


### PR DESCRIPTION
Applied the same styles to Laravel's default emails like reset password, email confirmation etc. Just to make it match with the rest of emails.

<img width="1000" alt="Screenshot 2023-08-23 at 09 03 29" src="https://github.com/brendt/rfc-vote/assets/35465417/b0ff7669-4e07-4a84-acb9-5b463ee4cee5">
