### PR TITLE
🐛 Fixed style bug when clicking on nav link on mobile

### DIFF
--- a/resources/views/components/navbar/link.blade.php
+++ b/resources/views/components/navbar/link.blade.php
@@ -14,7 +14,7 @@
 
     <div
         @class([
-            'absolute bottom-0 top-7 -left-0.5 -right-0.5 transition-transform duration-300',
+            'hidden md:block absolute bottom-0 top-7 -left-0.5 -right-0.5 transition-transform duration-300',
             'group-hover:opacity-100 group-hover:translate-y-0 h-1 bg-purple-200 rounded-full',
             $isActive ? 'opacity-0 md:opacity-100' : 'opacity-0 -translate-y-1',
         ])


### PR DESCRIPTION
Fixed styling bug on mobile when clicking the link, not necessary hover was effect was appearing:
![image](https://github.com/brendt/rfc-vote/assets/35465417/2fd54922-7899-48aa-9e7a-e5bcded18979)
