### PR TITLE
Update profile code refactoring

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -28,15 +28,13 @@ final readonly class ProfileController
 
     public function update(UpdateRequest $request): RedirectResponse
     {
-        $validated = collect($request->validated());
-        $user = $request->user();
+        $attrs = collect($request->validated())->except('avatar');
 
-        if ($validated->has('avatar')) {
-            $avatar = $request->file('avatar')?->store('public/avatars');
-            $validated->put('avatar', $avatar);
+        if ($request->avatar !== null) {
+            $attrs->put('avatar', $request->file('avatar')?->store('public/avatars'));
         }
 
-        $user->update($validated->toArray());
+        $request->user()->update($attrs->toArray());
 
         flash('Profile updated successfully');
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -25,19 +25,9 @@ final readonly class ProfileController
         ]);
     }
 
-    public function update(Request $request)
+    public function update(UpdateRequest $request): RedirectResponse
     {
-        $validated = collect($request->validate([
-            'name' => ['required', 'string'],
-            'username' => ['required', 'string', Rule::unique('users', 'username')->ignore($request->user()->id)],
-            'website_url' => ['nullable', 'url'],
-            'github_url' => ['nullable', 'url'],
-            'twitter_url' => ['nullable', 'url'],
-            'avatar' => [
-                'nullable',
-                File::types(['png', 'jpg'])->max(1024),
-            ],
-        ]));
+        $validated = collect($request->validated());
 
         $user = $request->user();
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -29,15 +29,14 @@ final readonly class ProfileController
     public function update(UpdateRequest $request): RedirectResponse
     {
         $validated = collect($request->validated());
-
         $user = $request->user();
-
-        $user->update($validated->except('avatar')->toArray());
 
         if ($validated->has('avatar')) {
             $avatar = $request->file('avatar')?->store('public/avatars');
-            $user->update(compact('avatar'));
+            $validated->put('avatar', $avatar);
         }
+
+        $user->update($validated->toArray());
 
         flash('Profile updated successfully');
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -4,13 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Actions\Fortify\PasswordValidationRules;
 use App\Actions\RequestEmailChange;
+use App\Http\Requests\Profile\UpdateRequest;
 use App\Models\EmailChangeRequest;
 use App\Models\VerificationRequest;
 use App\Models\VerificationRequestStatus;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\File;
 
 final readonly class ProfileController
 {
@@ -31,16 +32,11 @@ final readonly class ProfileController
 
         $user = $request->user();
 
-        $user->update($validated->except('avatar')->all());
+        $user->update($validated->except('avatar')->toArray());
 
-        if ($validated['avatar'] ?? null) {
-            $file = $request->file('avatar');
-
-            $path = $file->store(path: 'public/avatars');
-
-            $user->update([
-                'avatar' => $path,
-            ]);
+        if ($validated->has('avatar')) {
+            $avatar = $request->file('avatar')?->store('public/avatars');
+            $user->update(compact('avatar'));
         }
 
         flash('Profile updated successfully');

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -20,7 +20,7 @@ class UpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string'],
+            'name' => ['required', 'string', 'max:255'],
             'username' => ['required', 'string', Rule::unique('users', 'username')->ignore($this->user()->id)],
             'website_url' => ['nullable', 'url'],
             'github_url' => ['nullable', 'url'],

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Profile;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class UpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    /**
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'username' => ['required', 'string', Rule::unique('users', 'username')->ignore($this->user()->id)],
+            'website_url' => ['nullable', 'url'],
+            'github_url' => ['nullable', 'url'],
+            'twitter_url' => ['nullable', 'url'],
+            'avatar' => ['nullable', File::types(['png', 'jpg'])->max(1024)],
+        ];
+    }
+}

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -27,9 +27,9 @@ class UpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique('users', 'username')->ignore($this->user()->id),
             ],
-            'website_url' => ['nullable', 'url'],
-            'github_url' => ['nullable', 'url'],
-            'twitter_url' => ['nullable', 'url'],
+            'website_url' => ['nullable', 'max:255', 'url'],
+            'github_url' => ['nullable', 'max:255', 'url'],
+            'twitter_url' => ['nullable', 'max:255', 'url'],
             'avatar' => ['nullable', File::types(['png', 'jpg'])->max(1024)],
         ];
     }

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -21,7 +21,12 @@ class UpdateRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'username' => ['required', 'string', Rule::unique('users', 'username')->ignore($this->user()->id)],
+            'username' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('users', 'username')->ignore($this->user()->id),
+            ],
             'website_url' => ['nullable', 'url'],
             'github_url' => ['nullable', 'url'],
             'twitter_url' => ['nullable', 'url'],

--- a/tests/Feature/Profile/ProfileInformationTest.php
+++ b/tests/Feature/Profile/ProfileInformationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Profile;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -11,22 +11,51 @@ class UpdateProfileTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
+    private string $url;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->url = action([ProfileController::class, 'update']);
+    }
+
     public function test_user_can_update_name_and_username(): void
     {
         $user = User::factory()->create();
 
-        $form_data = [
+        $formData = [
             'name' => 'Anna',
             'username' => 'anna',
         ];
 
-        $this->actingAs($user)
-            ->post(action([ProfileController::class, 'update']), $form_data);
+        $this->actingAs($user)->post($this->url, $formData);
 
         $this->assertDatabaseHas('users', [
             'id' => $user->id,
-            'name' => $form_data['name'],
-            'username' => $form_data['username'],
+            'name' => $formData['name'],
+            'username' => $formData['username'],
         ]);
+    }
+
+    public function test_username_is_required(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = ['name' => 'Sam'];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('username');
+    }
+
+    public function test_name_is_required(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = ['username' => 'serhii-cho'];
+
+        $this->actingAs($user)
+             ->post($this->url, $formData)
+             ->assertSessionHasErrors('name');
     }
 }

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Profile;
+
+use App\Http\Controllers\ProfileController;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class UpdateProfileTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_user_can_update_name_and_username(): void
+    {
+        $user = User::factory()->create();
+
+        $form_data = [
+            'name' => 'Anna',
+            'username' => 'anna',
+        ];
+
+        $this->actingAs($user)
+            ->post(action([ProfileController::class, 'update']), $form_data);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'name' => $form_data['name'],
+            'username' => $form_data['username'],
+        ]);
+    }
+}

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -164,8 +164,7 @@ class UpdateProfileTest extends TestCase
             'avatar' => UploadedFile::fake()->image('avatar.jpg'),
         ];
 
-        $this->actingAs($user)
-            ->post($this->url, $formData);
+        $this->actingAs($user)->post($this->url, $formData);
 
         $fileName = $formData['avatar']->hashName();
 
@@ -174,6 +173,43 @@ class UpdateProfileTest extends TestCase
         $this->assertDatabaseHas('users', [
             'id' => $user->id,
             'avatar' => "public/avatars/{$fileName}",
+        ]);
+    }
+
+    public function test_avatar_is_not_updated_to_null_when_avatar_in_request_is_null(): void
+    {
+        $avatar = 'public/avatars/alex.jpg';
+        $user = User::factory()->create(compact('avatar'));
+
+        $formData = [
+            'username' => 'alex',
+            'name' => 'alex',
+            'avatar' => null,
+        ];
+
+        $this->actingAs($user)->post($this->url, $formData);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'avatar' => $avatar,
+        ]);
+    }
+
+    public function test_avatar_is_not_updated_to_null_when_not_provided(): void
+    {
+        $avatar = 'public/avatars/sam.jpg';
+        $user = User::factory()->create(compact('avatar'));
+
+        $formData = [
+            'username' => 'sam',
+            'name' => 'Sam',
+        ];
+
+        $this->actingAs($user)->post($this->url, $formData);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'avatar' => $avatar,
         ]);
     }
 }

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -58,4 +58,18 @@ class UpdateProfileTest extends TestCase
              ->post($this->url, $formData)
              ->assertSessionHasErrors('name');
     }
+
+    public function test_name_cannot_be_more_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'name' => str_repeat('a', 256),
+            'username' => 'anna',
+        ];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('name');
+    }
 }

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -72,4 +72,18 @@ class UpdateProfileTest extends TestCase
             ->post($this->url, $formData)
             ->assertSessionHasErrors('name');
     }
+
+    public function test_username_cannot_be_more_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'username' => str_repeat('a', 256),
+            'name' => 'anna',
+        ];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('username');
+    }
 }

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -86,4 +86,49 @@ class UpdateProfileTest extends TestCase
             ->post($this->url, $formData)
             ->assertSessionHasErrors('username');
     }
+
+    public function test_website_url_cannot_be_more_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'username' => 'anna',
+            'name' => 'Anna',
+            'website_url' => str_repeat('a', 256),
+        ];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('website_url');
+    }
+
+    public function test_github_url_cannot_be_more_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'username' => 'anna',
+            'name' => 'Anna',
+            'github_url' => str_repeat('a', 256),
+        ];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('github_url');
+    }
+
+    public function test_twitter_url_cannot_be_more_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'username' => 'anna',
+            'name' => 'Anna',
+            'twitter_url' => str_repeat('a', 256),
+        ];
+
+        $this->actingAs($user)
+            ->post($this->url, $formData)
+            ->assertSessionHasErrors('twitter_url');
+    }
 }

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -32,8 +32,27 @@ class UpdateProfileTest extends TestCase
 
         $this->assertDatabaseHas('users', [
             'id' => $user->id,
-            'name' => $formData['name'],
-            'username' => $formData['username'],
+            ...$formData,
+        ]);
+    }
+
+    public function test_user_can_update_urls(): void
+    {
+        $user = User::factory()->create();
+
+        $formData = [
+            'name' => 'Anna',
+            'username' => 'anna',
+            'website_url' => 'https://anna.com',
+            'twitter_url' => 'https://twitter.com/anna',
+            'github_url' => 'https://github.com/anna',
+        ];
+
+        $this->actingAs($user)->post($this->url, $formData);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            ...$formData,
         ]);
     }
 


### PR DESCRIPTION
1. Added bunch of tests for testing `update` action on `ProfileController`.
2. Refactored `update` action from `ProfileController` from this:

```php
public function update(Request $request)
{
    $validated = collect($request->validate([
        'name' => ['required', 'string'],
        'username' => ['required', 'string', Rule::unique('users', 'username')->ignore($request->user()->id)],
        'website_url' => ['nullable', 'url'],
        'github_url' => ['nullable', 'url'],
        'twitter_url' => ['nullable', 'url'],
        'avatar' => [
            'nullable',
            File::types(['png', 'jpg'])->max(1024),
        ],
    ]));

    $user = $request->user();

    $user->update($validated->except('avatar')->all());

    if ($validated['avatar'] ?? null) {
        $file = $request->file('avatar');

        $path = $file->store(path: 'public/avatars');

        $user->update([
            'avatar' => $path,
        ]);
    }

    flash('Profile updated successfully');

    return redirect()->action([self::class, 'edit']);
}
```

to this:

```php
public function update(UpdateRequest $request): RedirectResponse
{
    $attrs = collect($request->validated())->except('avatar');

    if ($request->avatar !== null) {
        $attrs->put('avatar', $request->file('avatar')?->store('public/avatars'));
    }

    $request->user()->update($attrs->toArray());

    flash('Profile updated successfully');

    return redirect()->action([self::class, 'edit']);
}
```