### PR TITLE
Upgrade PHPStan to Level 8

### DIFF
--- a/app/Actions/AcceptVerificationRequest.php
+++ b/app/Actions/AcceptVerificationRequest.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Http\Controllers\PublicProfileController;
+use App\Models\User;
 use App\Models\UserFlair;
 use App\Models\VerificationRequest;
 use App\Models\VerificationRequestStatus;
@@ -23,9 +24,12 @@ final readonly class AcceptVerificationRequest
             'flair' => $flair,
         ]);
 
+        /** @var User $authenticatedUser */
+        $authenticatedUser = auth()->user();
+
         ($this->sendMessage)(
             to: $request->user,
-            sender: auth()->user(),
+            sender: $authenticatedUser,
             url: action(PublicProfileController::class, $request->user),
             body: <<<TXT
             Your verification request was accepted! We'll now show the {$flair->value} badge besides your username.

--- a/app/Actions/DenyVerificationRequest.php
+++ b/app/Actions/DenyVerificationRequest.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Http\Controllers\ProfileController;
+use App\Models\User;
 use App\Models\VerificationRequest;
 use App\Models\VerificationRequestStatus;
 
@@ -18,9 +19,12 @@ final readonly class DenyVerificationRequest
             'status' => VerificationRequestStatus::DENIED,
         ]);
 
+        /** @var User $authenticatedUser */
+        $authenticatedUser = auth()->user();
+
         ($this->sendMessage)(
             to: $request->user,
-            sender: auth()->user(),
+            sender: $authenticatedUser,
             url: action([ProfileController::class, 'edit']),
             body: <<<'TXT'
             Unfortunately, your verification request has been denied. You can always reapply on your profile page if you think this was in error.

--- a/app/Actions/Fortify/PasswordValidationRules.php
+++ b/app/Actions/Fortify/PasswordValidationRules.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Fortify;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Laravel\Fortify\Rules\Password;
 
 trait PasswordValidationRules
@@ -9,7 +10,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<int, array<int, ValidationRule|string>|ValidationRule|string>
      */
     protected function passwordRules(): array
     {

--- a/app/Actions/Fortify/PasswordValidationRules.php
+++ b/app/Actions/Fortify/PasswordValidationRules.php
@@ -10,7 +10,7 @@ trait PasswordValidationRules
     /**
      * Get the validation rules used to validate passwords.
      *
-     * @return array<int, array<int, ValidationRule|string>|ValidationRule|string>
+     * @return array<int, array<int, ValidationRule|Password|string>|ValidationRule|Password|string>
      */
     protected function passwordRules(): array
     {

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -4,6 +4,7 @@ namespace App\Actions\Fortify;
 
 use App\Models\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
@@ -13,7 +14,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * Validate and update the given user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array{name: string, email: string, photo: ?UploadedFile}  $input
      */
     public function update(User $user, array $input): void
     {

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -42,7 +42,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * Update the given verified user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, string|UploadedFile|null>  $input
      */
     protected function updateVerifiedUser(User $user, array $input): void
     {

--- a/app/Actions/SendUserMail.php
+++ b/app/Actions/SendUserMail.php
@@ -11,7 +11,7 @@ final readonly class SendUserMail
 {
     public function __invoke(User $user, Mailable $mailable): void
     {
-        if (! $user->email_optin) {
+        if (! $user->email_optin || ! method_exists($mailable, 'envelope')) {
             return;
         }
 

--- a/app/Console/Commands/RfcSyncCommand.php
+++ b/app/Console/Commands/RfcSyncCommand.php
@@ -20,7 +20,7 @@ class RfcSyncCommand extends Command
         $rss = Feed::loadRss('https://externals.io/rss');
 
         foreach ($rss->item as $item) {
-            if (! Str::startsWith($item->title ?? null, ['[VOTE]'])) {
+            if (! Str::startsWith((string) ($item->title ?? null), ['[VOTE]'])) {
                 continue;
             }
 

--- a/app/Console/Commands/RfcSyncCommand.php
+++ b/app/Console/Commands/RfcSyncCommand.php
@@ -6,6 +6,7 @@ use App\Models\Rfc;
 use Feed;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use SimpleXMLElement;
 
 class RfcSyncCommand extends Command
 {
@@ -15,6 +16,7 @@ class RfcSyncCommand extends Command
 
     public function handle(): void
     {
+        /** @var SimpleXMLElement $rss */
         $rss = Feed::loadRss('https://externals.io/rss');
 
         foreach ($rss->item as $item) {

--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -11,7 +11,7 @@ final readonly class AboutController
     {
         $contributors = array_map(
             fn (array $item) => new Contributor(...$item),
-            json_decode(file_get_contents(__DIR__.'/../../../contributors.json'), true)['contributors'] ?? [],
+            json_decode(file_get_contents(__DIR__.'/../../../contributors.json') ?: '{}', true)['contributors'] ?? [],
         );
 
         return view('about', [

--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Contributor;
+use Illuminate\Contracts\View\View;
 
 final readonly class AboutController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         $contributors = array_map(
             fn (array $item) => new Contributor(...$item),

--- a/app/Http/Controllers/DisableEmailOptinController.php
+++ b/app/Http/Controllers/DisableEmailOptinController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 final readonly class DisableEmailOptinController
 {
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): RedirectResponse
     {
         $user = $request->user();
 

--- a/app/Http/Controllers/EnableEmailOptinController.php
+++ b/app/Http/Controllers/EnableEmailOptinController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 final readonly class EnableEmailOptinController
 {
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): RedirectResponse
     {
         $user = $request->user();
 

--- a/app/Http/Controllers/EndRfcController.php
+++ b/app/Http/Controllers/EndRfcController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Rfc;
+use Illuminate\Http\RedirectResponse;
 
 final readonly class EndRfcController
 {
-    public function __invoke(Rfc $rfc)
+    public function __invoke(Rfc $rfc): RedirectResponse
     {
         $rfc->update([
             'ends_at' => now(),

--- a/app/Http/Controllers/ForgotPasswordController.php
+++ b/app/Http/Controllers/ForgotPasswordController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class ForgotPasswordController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('auth.forgot-password');
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -5,12 +5,13 @@ namespace App\Http\Controllers;
 use App\Models\Argument;
 use App\Models\ArgumentVote;
 use App\Models\Rfc;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 final readonly class HomeController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         $user = auth()->user();
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -16,7 +16,9 @@ final readonly class HomeController
 
         $rfcs = Rfc::query()
             ->where('published_at', '<=', now()->startOfDay())
-            ->where(fn (Builder $builder) => $builder->whereNull('ends_at')->orWhere('ends_at', '>', now()))
+            ->where(function (Builder $builder) {
+                $builder->whereNull('ends_at')->orWhere('ends_at', '>', now());
+            })
             ->orderByDesc('created_at')
             ->with(['arguments', 'yesArguments', 'noArguments'])
             ->limit(3)

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class LoginController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('login');
     }

--- a/app/Http/Controllers/LogoutController.php
+++ b/app/Http/Controllers/LogoutController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class LogoutController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('logout');
     }

--- a/app/Http/Controllers/MailPreviewController.php
+++ b/app/Http/Controllers/MailPreviewController.php
@@ -8,7 +8,7 @@ use App\Models\User;
 
 final readonly class MailPreviewController
 {
-    public function __invoke()
+    public function __invoke(): string
     {
         abort_if(app()->isProduction(), 400);
 

--- a/app/Http/Controllers/MailPreviewController.php
+++ b/app/Http/Controllers/MailPreviewController.php
@@ -13,8 +13,8 @@ final readonly class MailPreviewController
         abort_if(app()->isProduction(), 400);
 
         $mail = new NewRfcMail(
-            rfc: Rfc::find(1),
-            user: User::find(1),
+            rfc: Rfc::query()->findOrFail(1),
+            user: User::query()->findOrFail(1),
         );
 
         return $mail->render();

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -8,7 +8,7 @@ final readonly class MessagesController
 {
     public function __invoke(): View
     {
-        $user = auth()->user()->load([
+        $user = auth()->user()?->load([
             'inboxMessages.user',
             'inboxMessages.sender',
             'archivedMessages.user',

--- a/app/Http/Controllers/MessagesController.php
+++ b/app/Http/Controllers/MessagesController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class MessagesController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         $user = auth()->user()->load([
             'inboxMessages.user',

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\PasswordValidationRules;
 use App\Actions\RequestEmailChange;
 use App\Http\Requests\Profile\UpdateRequest;
 use App\Models\EmailChangeRequest;
+use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -38,7 +39,10 @@ final readonly class ProfileController
             $attrs->put('avatar', $avatar->store('public/avatars'));
         }
 
-        $request->user()->update($attrs->toArray());
+        /** @var User $user */
+        $user = $request->user();
+
+        $user->update($attrs->toArray());
 
         flash('Profile updated successfully');
 
@@ -47,10 +51,11 @@ final readonly class ProfileController
 
     public function updateEmail(Request $request): RedirectResponse
     {
+        /** @var User $user */
         $user = $request->user();
 
         $validated = $request->validate([
-            'email' => ['required', 'string', 'email', Rule::unique('users', 'email')->ignore($request->user()->id)],
+            'email' => ['required', 'string', 'email', Rule::unique('users', 'email')->ignore($user->id)],
             'email_optin' => ['nullable'],
         ]);
 
@@ -74,6 +79,7 @@ final readonly class ProfileController
 
     public function updatePassword(Request $request): RedirectResponse
     {
+        /** @var User $user */
         $user = $request->user();
 
         if ($user->password) {
@@ -114,6 +120,7 @@ final readonly class ProfileController
             abort(404, 'Link expired');
         }
 
+        /** @var User $user */
         $user = $emailChangeRequest->user;
 
         $user->update([
@@ -135,8 +142,11 @@ final readonly class ProfileController
             'motivation' => ['required', 'string'],
         ]);
 
+        /** @var User $user */
+        $user = $request->user();
+
         $createVerificationRequest(
-            user: $request->user(),
+            user: $user,
             motivation: $validated['motivation']
         );
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -120,10 +120,7 @@ final readonly class ProfileController
             abort(404, 'Link expired');
         }
 
-        /** @var User $user */
-        $user = $emailChangeRequest->user;
-
-        $user->update([
+        $emailChangeRequest->user->update([
             'email' => $emailChangeRequest->new_email,
         ]);
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -102,11 +102,11 @@ final readonly class ProfileController
         $emailChangeRequest = EmailChangeRequest::query()->where('token', $token)->first();
 
         if (! $emailChangeRequest) {
-            abort('403', 'Email Expired');
+            abort(403, 'Email Expired');
         }
 
         if (now()->greaterThan($emailChangeRequest->created_at->addMinutes(30))) {
-            abort('404', 'Link expired');
+            abort(404, 'Link expired');
         }
 
         $user = $emailChangeRequest->user;

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\PasswordValidationRules;
 use App\Actions\RequestEmailChange;
 use App\Http\Requests\Profile\UpdateRequest;
 use App\Models\EmailChangeRequest;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -16,7 +17,7 @@ final readonly class ProfileController
 {
     use PasswordValidationRules;
 
-    public function edit()
+    public function edit(): View
     {
         $user = auth()->user();
 
@@ -27,7 +28,7 @@ final readonly class ProfileController
 
     public function update(UpdateRequest $request): RedirectResponse
     {
-        $attrs = collect($request->validated())->except('avatar');
+        $attrs = collect($request->safe()->except('avatar'));
 
         if ($request->avatar !== null) {
             $attrs->put('avatar', $request->file('avatar')?->store('public/avatars'));
@@ -40,7 +41,7 @@ final readonly class ProfileController
         return redirect()->action([self::class, 'edit']);
     }
 
-    public function updateEmail(Request $request)
+    public function updateEmail(Request $request): RedirectResponse
     {
         $user = $request->user();
 
@@ -67,7 +68,7 @@ final readonly class ProfileController
         return redirect()->action([self::class, 'edit']);
     }
 
-    public function updatePassword(Request $request)
+    public function updatePassword(Request $request): RedirectResponse
     {
         $user = $request->user();
 
@@ -97,7 +98,7 @@ final readonly class ProfileController
         return redirect()->action([self::class, 'edit']);
     }
 
-    public function verifyEmail(string $token)
+    public function verifyEmail(string $token): RedirectResponse
     {
         $emailChangeRequest = EmailChangeRequest::query()->where('token', $token)->first();
 
@@ -125,7 +126,7 @@ final readonly class ProfileController
     public function requestVerification(
         CreateVerificationRequest $createVerificationRequest,
         Request $request,
-    ) {
+    ): RedirectResponse {
         $validated = $request->validate([
             'motivation' => ['required', 'string'],
         ]);

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,6 +10,7 @@ use App\Models\EmailChangeRequest;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
 
@@ -31,7 +32,10 @@ final readonly class ProfileController
         $attrs = collect($request->safe()->except('avatar'));
 
         if ($request->avatar !== null) {
-            $attrs->put('avatar', $request->file('avatar')?->store('public/avatars'));
+            /** @var UploadedFile $avatar */
+            $avatar = $request->file('avatar');
+
+            $attrs->put('avatar', $avatar->store('public/avatars'));
         }
 
         $request->user()->update($attrs->toArray());

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use Illuminate\Contracts\View\View;
 
 final readonly class PublicProfileController
 {
-    public function __invoke(User $user)
+    public function __invoke(User $user): View
     {
         $user->load([
             'arguments.rfc',

--- a/app/Http/Controllers/PublishRfcController.php
+++ b/app/Http/Controllers/PublishRfcController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Rfc;
+use Illuminate\Http\RedirectResponse;
 
 final readonly class PublishRfcController
 {
-    public function __invoke(Rfc $rfc)
+    public function __invoke(Rfc $rfc): RedirectResponse
     {
         $rfc->update([
             'published_at' => now(),

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class RegisterController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('register');
     }

--- a/app/Http/Controllers/RfcAdminController.php
+++ b/app/Http/Controllers/RfcAdminController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Rfc;
+use Illuminate\Contracts\View\View;
 
 final readonly class RfcAdminController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         $rfcs = Rfc::query()->orderByDesc('created_at')->get();
 

--- a/app/Http/Controllers/RfcCreateController.php
+++ b/app/Http/Controllers/RfcCreateController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\RfcRequest;
 use App\Models\Rfc;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 
 final readonly class RfcCreateController
 {
-    public function create()
+    public function create(): View
     {
         return view('rfc-form', [
             'rfc' => new Rfc(),
@@ -15,7 +17,7 @@ final readonly class RfcCreateController
         ]);
     }
 
-    public function store(RfcRequest $request)
+    public function store(RfcRequest $request): RedirectResponse
     {
         $rfc = new Rfc($request->validated());
         $rfc->save();

--- a/app/Http/Controllers/RfcDetailController.php
+++ b/app/Http/Controllers/RfcDetailController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Argument;
 use App\Models\Rfc;
 use App\Support\Meta;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 
 final readonly class RfcDetailController
@@ -13,7 +14,7 @@ final readonly class RfcDetailController
     {
     }
 
-    public function __invoke(Rfc $rfc)
+    public function __invoke(Rfc $rfc): View
     {
         $rfc->load([
             'arguments.user',

--- a/app/Http/Controllers/RfcDetailController.php
+++ b/app/Http/Controllers/RfcDetailController.php
@@ -45,7 +45,9 @@ final readonly class RfcDetailController
 
         $additionalRfcs = Rfc::query()
             ->where('published_at', '<=', now()->startOfDay())
-            ->where(fn (Builder $builder) => $builder->whereNull('ends_at')->orWhere('ends_at', '>', now()))
+            ->where(function (Builder $builder) {
+                $builder->whereNull('ends_at')->orWhere('ends_at', '>', now());
+            })
             ->where('id', '!=', $rfc->id)
             ->when(filled($user), fn (Builder $builder) => $builder->whereDoesntHave('arguments', fn (Builder $builder) => $builder->where('user_id', $user->id)))
             ->with(['arguments', 'yesArguments', 'noArguments'])

--- a/app/Http/Controllers/RfcDetailController.php
+++ b/app/Http/Controllers/RfcDetailController.php
@@ -32,7 +32,7 @@ final readonly class RfcDetailController
 
         $this->meta
             ->title($rfc->title)
-            ->description($rfc->teaser)
+            ->description((string) $rfc->teaser)
             ->image(action(\App\Http\Controllers\RfcMetaImageController::class, $rfc));
 
         if ($user) {
@@ -50,7 +50,7 @@ final readonly class RfcDetailController
                 $builder->whereNull('ends_at')->orWhere('ends_at', '>', now());
             })
             ->where('id', '!=', $rfc->id)
-            ->when(filled($user), fn (Builder $builder) => $builder->whereDoesntHave('arguments', fn (Builder $builder) => $builder->where('user_id', $user->id)))
+            ->when(filled($user), fn (Builder $builder) => $builder->whereDoesntHave('arguments', fn (Builder $builder) => $builder->where('user_id', $user?->id)))
             ->with(['arguments', 'yesArguments', 'noArguments'])
             ->inRandomOrder()
             ->limit(3)

--- a/app/Http/Controllers/RfcEditController.php
+++ b/app/Http/Controllers/RfcEditController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\RfcRequest;
 use App\Models\Rfc;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 
 final readonly class RfcEditController
 {
-    public function edit(Rfc $rfc)
+    public function edit(Rfc $rfc): View
     {
         return view('rfc-form', [
             'rfc' => $rfc,
@@ -15,7 +17,7 @@ final readonly class RfcEditController
         ]);
     }
 
-    public function update(Rfc $rfc, RfcRequest $request)
+    public function update(Rfc $rfc, RfcRequest $request): RedirectResponse
     {
         $rfc->update($request->validated());
 

--- a/app/Http/Controllers/RfcMetaImageController.php
+++ b/app/Http/Controllers/RfcMetaImageController.php
@@ -23,6 +23,6 @@ final readonly class RfcMetaImageController
             $rfc->refresh();
         }
 
-        return response(base64_decode($rfc->meta_image))->header('Content-Type', 'image/png');
+        return response(base64_decode((string) $rfc->meta_image))->header('Content-Type', 'image/png');
     }
 }

--- a/app/Http/Controllers/RfcMetaImageController.php
+++ b/app/Http/Controllers/RfcMetaImageController.php
@@ -5,10 +5,11 @@ namespace App\Http\Controllers;
 use App\Jobs\RenderMetaImageJob;
 use App\Models\Rfc;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 final readonly class RfcMetaImageController
 {
-    public function __invoke(Rfc $rfc, Request $request)
+    public function __invoke(Rfc $rfc, Request $request): Response|string
     {
         if ($request->has('html')) {
             return view('rfc-meta', [

--- a/app/Http/Controllers/SocialiteCallbackController.php
+++ b/app/Http/Controllers/SocialiteCallbackController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\GenerateUsername;
 use App\Models\User;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
@@ -11,7 +12,7 @@ use Laravel\Socialite\Facades\Socialite;
 
 final readonly class SocialiteCallbackController
 {
-    public function __invoke(string $driver, Request $request)
+    public function __invoke(string $driver, Request $request): RedirectResponse
     {
         if ($request->has('error') || $request->missing('code')) {
             return redirect()->route('login');

--- a/app/Http/Controllers/SocialiteCallbackController.php
+++ b/app/Http/Controllers/SocialiteCallbackController.php
@@ -48,7 +48,7 @@ final readonly class SocialiteCallbackController
 
     private function resolveUsername(SocialiteUser $socialiteUser): string
     {
-        $username = (new GenerateUsername)($socialiteUser->getNickname()); // normalize username to our rules
+        $username = (new GenerateUsername)((string) $socialiteUser->getNickname()); // normalize username to our rules
 
         /**
          * We need to check for duplicates, this is because users can register directly on the app and because of

--- a/app/Http/Controllers/SocialiteRedirectController.php
+++ b/app/Http/Controllers/SocialiteRedirectController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Laravel\Socialite\Facades\Socialite;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 
 final readonly class SocialiteRedirectController
 {
-    public function __invoke(string $driver)
+    public function __invoke(string $driver): RedirectResponse|SymfonyRedirectResponse
     {
         return Socialite::driver($driver)->redirect();
     }

--- a/app/Http/Controllers/VerificationRequestsAdminController.php
+++ b/app/Http/Controllers/VerificationRequestsAdminController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\View\View;
+
 final readonly class VerificationRequestsAdminController
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('verification-request-admin');
     }

--- a/app/Http/Controllers/ViewMessageController.php
+++ b/app/Http/Controllers/ViewMessageController.php
@@ -4,10 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Models\Message;
 use App\Models\MessageStatus;
+use Illuminate\Http\RedirectResponse;
 
 final readonly class ViewMessageController
 {
-    public function __invoke(Message $message)
+    public function __invoke(Message $message): RedirectResponse
     {
         $message->update(['status' => MessageStatus::READ]);
 

--- a/app/Http/Livewire/ArgumentList.php
+++ b/app/Http/Livewire/ArgumentList.php
@@ -60,7 +60,7 @@ class ArgumentList extends Component
     public function refresh(): void
     {
         $this->rfc->refresh();
-        $this->user->refresh();
+        $this->user?->refresh();
         $this->isConfirmingDelete = null;
     }
 

--- a/app/Http/Livewire/ArgumentList.php
+++ b/app/Http/Livewire/ArgumentList.php
@@ -30,7 +30,7 @@ class ArgumentList extends Component
     public ?Argument $showingComments = null;
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     protected $listeners = [
         Events::ARGUMENT_CREATED->value => 'refresh',

--- a/app/Http/Livewire/ArgumentList.php
+++ b/app/Http/Livewire/ArgumentList.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\RfcDetailController;
 use App\Models\Argument;
 use App\Models\Rfc;
 use App\Models\User;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Session;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -28,11 +29,14 @@ class ArgumentList extends Component
 
     public ?Argument $showingComments = null;
 
+    /**
+     * @var string[]
+     */
     protected $listeners = [
         Events::ARGUMENT_CREATED->value => 'refresh',
     ];
 
-    public function render()
+    public function render(): View
     {
         $userArgument = $this->user?->getArgumentForRfc($this->rfc);
 

--- a/app/Http/Livewire/MessageList.php
+++ b/app/Http/Livewire/MessageList.php
@@ -5,13 +5,14 @@ namespace App\Http\Livewire;
 use App\Models\Message;
 use App\Models\MessageStatus;
 use App\Models\User;
+use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
 class MessageList extends Component
 {
     public User $user;
 
-    public function render()
+    public function render(): View
     {
         return view('livewire.message-list');
     }

--- a/app/Http/Livewire/RfcCounter.php
+++ b/app/Http/Livewire/RfcCounter.php
@@ -14,7 +14,7 @@ class RfcCounter extends Component
     public Rfc $rfc;
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     protected $listeners = [
         Events::USER_VOTED_FOR_ARGUMENT->value => 'refresh',

--- a/app/Http/Livewire/RfcCounter.php
+++ b/app/Http/Livewire/RfcCounter.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire;
 
 use App\Models\Rfc;
 use App\Models\VoteType;
+use Illuminate\View\View;
 use Livewire\Component;
 
 class RfcCounter extends Component
@@ -12,18 +13,21 @@ class RfcCounter extends Component
 
     public Rfc $rfc;
 
+    /**
+     * @var string[]
+     */
     protected $listeners = [
         Events::USER_VOTED_FOR_ARGUMENT->value => 'refresh',
         Events::ARGUMENT_DELETED->value => 'refresh',
         Events::ARGUMENT_CREATED->value => 'refresh',
     ];
 
-    public function booted()
+    public function booted(): void
     {
         $this->rfc = $this->rfc->withoutRelations();
     }
 
-    public function render()
+    public function render(): View
     {
         $count = match ($this->voteType) {
             VoteType::YES => $this->rfc->count_yes,

--- a/app/Http/Livewire/UsernameInput.php
+++ b/app/Http/Livewire/UsernameInput.php
@@ -3,10 +3,8 @@
 namespace App\Http\Livewire;
 
 use App\Rules\UsernameFormatRule;
-use Illuminate\Contracts\Foundation\Application as ApplicationAlias;
-use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\View\View;
-use Illuminate\Foundation\Application;
 use Livewire\Component;
 
 class UsernameInput extends Component
@@ -21,6 +19,9 @@ class UsernameInput extends Component
 
     public bool $required;
 
+    /**
+     * @return array<string, array<int, string|ValidationRule>|ValidationRule|string>
+     */
     protected function rules(): array
     {
         return [
@@ -33,7 +34,7 @@ class UsernameInput extends Component
         $this->validateOnly($propertyName);
     }
 
-    public function render(): View|Application|Factory|ApplicationAlias
+    public function render(): View
     {
         return view('livewire.username-input');
     }

--- a/app/Http/Livewire/VerificationRequestsList.php
+++ b/app/Http/Livewire/VerificationRequestsList.php
@@ -52,7 +52,7 @@ class VerificationRequestsList extends Component
 
         app(AcceptVerificationRequest::class)(
             $request,
-            UserFlair::from($this->flair)
+            UserFlair::from((string) $this->flair)
         );
 
         $this->refresh();

--- a/app/Http/Livewire/VerificationRequestsList.php
+++ b/app/Http/Livewire/VerificationRequestsList.php
@@ -7,12 +7,13 @@ use App\Actions\DenyVerificationRequest;
 use App\Models\UserFlair;
 use App\Models\VerificationRequest;
 use App\Models\VerificationRequestStatus;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Livewire\Component;
 
 class VerificationRequestsList extends Component
 {
-    /** @var \Illuminate\Support\Collection<\App\Models\VerificationRequest> */
+    /** @var Collection<int, VerificationRequest> */
     public Collection $pendingRequests;
 
     public ?VerificationRequest $isAccepting = null;
@@ -26,7 +27,7 @@ class VerificationRequestsList extends Component
         $this->refresh();
     }
 
-    public function render()
+    public function render(): View
     {
         return view('livewire.verification-requests-list');
     }

--- a/app/Http/Livewire/VoteBar.php
+++ b/app/Http/Livewire/VoteBar.php
@@ -64,7 +64,7 @@ class VoteBar extends Component
 
     public function storeArgument(): void
     {
-        if (! $this->body || ! $this->voteType) {
+        if (! $this->body || ! $this->voteType || ! $this->user instanceof User) {
             return;
         }
 
@@ -87,7 +87,7 @@ class VoteBar extends Component
 
     public function refresh(): void
     {
-        $this->user->refresh();
+        $this->user?->refresh();
         $this->rfc->refresh();
 
         $userArgument = $this->user?->getArgumentForRfc($this->rfc);

--- a/app/Http/Livewire/VoteBar.php
+++ b/app/Http/Livewire/VoteBar.php
@@ -22,7 +22,7 @@ class VoteBar extends Component
     public ?string $body = null;
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     protected $listeners = [
         Events::ARGUMENT_CREATED->value => 'refresh',

--- a/app/Http/Livewire/VoteBar.php
+++ b/app/Http/Livewire/VoteBar.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\RfcDetailController;
 use App\Models\Rfc;
 use App\Models\User;
 use App\Models\VoteType;
+use Illuminate\Contracts\View\View;
 use Livewire\Component;
 use Session;
 
@@ -20,20 +21,23 @@ class VoteBar extends Component
 
     public ?string $body = null;
 
+    /**
+     * @var string[]
+     */
     protected $listeners = [
         Events::ARGUMENT_CREATED->value => 'refresh',
         Events::ARGUMENT_DELETED->value => 'refresh',
         Events::USER_VOTED_FOR_ARGUMENT->value => 'refresh',
     ];
 
-    public function mount()
+    public function mount(): void
     {
         $userArgument = $this->user?->getArgumentForRfc($this->rfc);
 
         $this->voteType = $userArgument?->vote_type;
     }
 
-    public function render()
+    public function render(): View
     {
         $userArgument = $this->user?->getArgumentForRfc($this->rfc);
         $rowCount = count(explode(PHP_EOL, $this->body ?? '')) + 1;

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AdminMiddleware
 {
     /**
-     *  @param  Closure(Request): (Response)  $next
+     *  @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response|RedirectResponse
     {

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -3,11 +3,16 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class AdminMiddleware
 {
-    public function handle(Request $request, Closure $next)
+    /**
+     *  @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response|RedirectResponse
     {
         $user = $request->user();
 

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -25,7 +25,7 @@ class UpdateRequest extends FormRequest
                 'required',
                 'string',
                 'max:255',
-                Rule::unique('users', 'username')->ignore($this->user()->id),
+                Rule::unique('users', 'username')->ignore($this->user()?->id),
             ],
             'website_url' => ['nullable', 'max:255', 'url'],
             'github_url' => ['nullable', 'max:255', 'url'],

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -15,7 +15,7 @@ class UpdateRequest extends FormRequest
     }
 
     /**
-     * @return array<string, ValidationRule|array|string>
+     * @return array<string, array<int, ValidationRule|string>|ValidationRule|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Profile/UpdateRequest.php
+++ b/app/Http/Requests/Profile/UpdateRequest.php
@@ -15,7 +15,7 @@ class UpdateRequest extends FormRequest
     }
 
     /**
-     * @return array<string, array<int, ValidationRule|string>|ValidationRule|string>
+     * @return array<string, array<int, ValidationRule|File|Rule|string>|ValidationRule|string>
      */
     public function rules(): array
     {

--- a/app/Http/Requests/RfcRequest.php
+++ b/app/Http/Requests/RfcRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class RfcRequest extends FormRequest
@@ -11,6 +12,9 @@ class RfcRequest extends FormRequest
         return true;
     }
 
+    /**
+     * @return array<string, array<int, ValidationRule|string>|ValidationRule|string>
+     */
     public function rules(): array
     {
         return [

--- a/app/Http/ViewComposers/AdminViewComposer.php
+++ b/app/Http/ViewComposers/AdminViewComposer.php
@@ -8,7 +8,7 @@ use Illuminate\View\View;
 
 class AdminViewComposer
 {
-    public function compose(View $view)
+    public function compose(View $view): void
     {
         $user = auth()->user();
 

--- a/app/Models/Argument.php
+++ b/app/Models/Argument.php
@@ -16,21 +16,33 @@ class Argument extends Model
         'vote_type' => VoteType::class,
     ];
 
+    /**
+     * @return BelongsTo<Rfc, self>
+     */
     public function rfc(): BelongsTo
     {
         return $this->belongsTo(Rfc::class);
     }
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return HasMany<ArgumentVote>
+     */
     public function votes(): HasMany
     {
         return $this->hasMany(ArgumentVote::class);
     }
 
+    /**
+     * @return HasMany<ArgumentComment>
+     */
     public function comments(): HasMany
     {
         return $this->hasMany(ArgumentComment::class);

--- a/app/Models/Argument.php
+++ b/app/Models/Argument.php
@@ -7,6 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property int $user_id
+ * @property int $rfc_id
+ * @property-read User $user
+ * @property-read Rfc $rfc
+ */
 class Argument extends Model
 {
     use HasFactory;

--- a/app/Models/ArgumentComment.php
+++ b/app/Models/ArgumentComment.php
@@ -10,6 +10,9 @@ class ArgumentComment extends Model
 {
     use HasFactory;
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/ArgumentComment.php
+++ b/app/Models/ArgumentComment.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property User $user
+ */
 class ArgumentComment extends Model
 {
     use HasFactory;

--- a/app/Models/ArgumentVote.php
+++ b/app/Models/ArgumentVote.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @property-read Argument $argument
+ */
 class ArgumentVote extends Model
 {
     use HasFactory;

--- a/app/Models/ArgumentVote.php
+++ b/app/Models/ArgumentVote.php
@@ -12,11 +12,17 @@ class ArgumentVote extends Model
     use HasFactory;
     use SoftDeletes;
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return BelongsTo<Argument, self>
+     */
     public function argument(): BelongsTo
     {
         return $this->belongsTo(Argument::class);

--- a/app/Models/Contributor.php
+++ b/app/Models/Contributor.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 final class Contributor
 {
+    /**
+     * @param  array<int, string>  $contributions
+     */
     public function __construct(
         public string $name,
         public string $url,

--- a/app/Models/EmailChangeRequest.php
+++ b/app/Models/EmailChangeRequest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property CarbonInterface $created_at
+ * @property-read User $user
  */
 class EmailChangeRequest extends Model
 {

--- a/app/Models/EmailChangeRequest.php
+++ b/app/Models/EmailChangeRequest.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class EmailChangeRequest extends Model
 {
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/EmailChangeRequest.php
+++ b/app/Models/EmailChangeRequest.php
@@ -2,9 +2,13 @@
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property CarbonInterface $created_at
+ */
 class EmailChangeRequest extends Model
 {
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property-read User $user
+ */
 class Message extends Model
 {
     use HasFactory;

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -14,11 +14,17 @@ class Message extends Model
         'status' => MessageStatus::class,
     ];
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function sender(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Rfc.php
+++ b/app/Models/Rfc.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Actions\SendNewRfcMails;
 use App\Http\Controllers\RfcDetailController;
 use App\Jobs\RenderMetaImageJob;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,6 +17,7 @@ use Spatie\Feed\FeedItem;
 
 /**
  * @property ?string $meta_image
+ * @property CarbonInterface $updated_at
  */
 class Rfc extends Model implements Feedable
 {
@@ -178,7 +180,7 @@ class Rfc extends Model implements Feedable
         return FeedItem::create()
             ->id((string) $this->id)
             ->title($this->title)
-            ->summary($this->teaser)
+            ->summary((string) $this->teaser)
             ->updated($this->updated_at)
             ->link(action(RfcDetailController::class, $this))
             ->authorName('Brent')

--- a/app/Models/Rfc.php
+++ b/app/Models/Rfc.php
@@ -14,6 +14,9 @@ use Illuminate\Support\Str;
 use Spatie\Feed\Feedable;
 use Spatie\Feed\FeedItem;
 
+/**
+ * @property ?string $meta_image
+ */
 class Rfc extends Model implements Feedable
 {
     use HasFactory;

--- a/app/Models/Rfc.php
+++ b/app/Models/Rfc.php
@@ -164,7 +164,7 @@ class Rfc extends Model implements Feedable
     public function toFeedItem(): FeedItem
     {
         return FeedItem::create()
-            ->id($this->id)
+            ->id((string) $this->id)
             ->title($this->title)
             ->summary($this->teaser)
             ->updated($this->updated_at)

--- a/app/Models/Rfc.php
+++ b/app/Models/Rfc.php
@@ -57,12 +57,15 @@ class Rfc extends Model implements Feedable
         return 'slug';
     }
 
+    /**
+     * @return HasMany<Argument>
+     */
     public function arguments(): HasMany
     {
         return $this->hasMany(Argument::class)->orderByDesc('vote_count')->orderByDesc('created_at');
     }
 
-    public function userArgument(User $user)
+    public function userArgument(User $user): ?Argument
     {
         return $this->arguments->first(fn (Argument $argument) => $argument->user_id === $user->id);
     }
@@ -72,18 +75,24 @@ class Rfc extends Model implements Feedable
         return $this->userArgument($user)?->exists() ?: false;
     }
 
+    /**
+     * @return HasMany<Argument>
+     */
     public function yesArguments(): HasMany
     {
         return $this->hasMany(Argument::class)->where('vote_type', VoteType::YES);
     }
 
+    /**
+     * @return HasMany<Argument>
+     */
     public function noArguments(): HasMany
     {
         return $this->hasMany(Argument::class)->where('vote_type', VoteType::NO);
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute<int, never>
+     * @return Attribute<int, never>
      */
     protected function countTotal(): Attribute
     {
@@ -93,7 +102,7 @@ class Rfc extends Model implements Feedable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute<int, never>
+     * @return Attribute<int, never>
      */
     protected function percentageYes(): Attribute
     {
@@ -109,7 +118,7 @@ class Rfc extends Model implements Feedable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute<int, never>
+     * @return Attribute<int, never>
      */
     protected function percentageNo(): Attribute
     {
@@ -153,6 +162,9 @@ class Rfc extends Model implements Feedable
         dispatch(new RenderMetaImageJob($this));
     }
 
+    /**
+     * @return Collection<int, self>
+     */
     public static function getFeedItems(): Collection
     {
         return self::query()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,20 +43,29 @@ class User extends Authenticatable implements MustVerifyEmail
         'flair' => UserFlair::class,
     ];
 
+    /**
+     * @var array<int, string>
+     */
     protected $appends = [
         'profile_photo_url',
     ];
 
-    public function getRouteKeyName()
+    public function getRouteKeyName(): string
     {
         return 'username';
     }
 
+    /**
+     * @return HasMany<UserMail>
+     */
     public function mails(): HasMany
     {
         return $this->hasMany(UserMail::class);
     }
 
+    /**
+     * @return BelongsToMany<Argument>
+     */
     public function viewedArguments(): BelongsToMany
     {
         return $this
@@ -64,42 +73,66 @@ class User extends Authenticatable implements MustVerifyEmail
             ->withTimestamps();
     }
 
+    /**
+     * @return HasMany<UserArgumentView>
+     */
     public function argumentViews(): HasMany
     {
         return $this->hasMany(UserArgumentView::class);
     }
 
+    /**
+     * @return HasMany<ArgumentVote>
+     */
     public function argumentVotes(): HasMany
     {
         return $this->hasMany(ArgumentVote::class);
     }
 
+    /**
+     * @return HasMany<Argument>
+     */
     public function arguments(): HasMany
     {
         return $this->hasMany(Argument::class);
     }
 
+    /**
+     * @return HasMany<EmailChangeRequest>
+     */
     public function emailChangeRequests(): HasMany
     {
         return $this->hasMany(EmailChangeRequest::class);
     }
 
+    /**
+     * @return HasMany<VerificationRequest>
+     */
     public function verificationRequests(): HasMany
     {
         return $this->hasMany(VerificationRequest::class);
     }
 
+    /**
+     * @return HasMany<VerificationRequest>
+     */
     public function pendingVerificationRequests(): HasMany
     {
         return $this->hasMany(VerificationRequest::class)->where('status', VerificationRequestStatus::PENDING);
     }
 
+    /**
+     * @return HasMany<Message>
+     */
     public function messages(): HasMany
     {
         return $this->hasMany(Message::class)
             ->orderByDesc('created_at');
     }
 
+    /**
+     * @return HasMany<Message>
+     */
     public function inboxMessages(): HasMany
     {
         return $this->hasMany(Message::class)
@@ -108,6 +141,9 @@ class User extends Authenticatable implements MustVerifyEmail
             ->orderByDesc('id');
     }
 
+    /**
+     * @return HasMany<Message>
+     */
     public function archivedMessages(): HasMany
     {
         return $this->hasMany(Message::class)
@@ -116,6 +152,9 @@ class User extends Authenticatable implements MustVerifyEmail
             ->orderByDesc('id');
     }
 
+    /**
+     * @return HasMany<Message>
+     */
     public function unreadMessages(): HasMany
     {
         return $this->hasMany(Message::class)
@@ -142,7 +181,7 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
-     * @return \Illuminate\Support\Collection<\App\Models\ArgumentVote>
+     * @return Collection<int, ArgumentVote>
      */
     public function getArgumentVotesForRfc(Rfc $rfc): Collection
     {

--- a/app/Models/VerificationRequest.php
+++ b/app/Models/VerificationRequest.php
@@ -10,10 +10,16 @@ class VerificationRequest extends Model
 {
     use HasFactory;
 
+    /**
+     * @var array<string, string|class-string>
+     */
     protected $casts = [
         'status' => VerificationRequestStatus::class,
     ];
 
+    /**
+     * @return BelongsTo<User, self>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/VerificationRequest.php
+++ b/app/Models/VerificationRequest.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property-read User $user
+ */
 class VerificationRequest extends Model
 {
     use HasFactory;

--- a/app/Rules/UsernameFormatRule.php
+++ b/app/Rules/UsernameFormatRule.php
@@ -55,8 +55,10 @@ class UsernameFormatRule implements ValidationRule, ValidatorAwareRule
         }
     }
 
-    public function setValidator(Validator $validator): void
+    public function setValidator(Validator $validator): static
     {
         $this->validator = $validator;
+
+        return $this;
     }
 }

--- a/app/Rules/UsernameFormatRule.php
+++ b/app/Rules/UsernameFormatRule.php
@@ -13,6 +13,9 @@ class UsernameFormatRule implements ValidationRule, ValidatorAwareRule
 {
     protected Validator $validator;
 
+    /**
+     * @var array<int, string>
+     */
     protected array $rules = [
         'required',
         'string',
@@ -44,6 +47,7 @@ class UsernameFormatRule implements ValidationRule, ValidatorAwareRule
 
         if ($validator->fails()) {
             $this->validator->errors()->merge($validator->errors());
+            /** @var string[][] $failedRules */
             $failedRules = $validator->failed()[$attribute];
             collect($failedRules)->each(
                 fn ($failedRuleItem, $failedRuleKey) => $this->validator->addFailure(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 3
+    level: 4

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 5
+    level: 6

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 7
+    level: 8

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 2
+    level: 3

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 1
+    level: 2

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 4
+    level: 5

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,4 @@ parameters:
     paths:
         - app
 
-    level: 6
+    level: 7


### PR DESCRIPTION
This PR increases the PHPStan level to 8, fixing errors at each level.

## Notes
- Had to add `meta_image` as an `@property` in Rfc model as Larastan is unable to detect it when using raw DB query in migration.
- The level 6 commit is the majority of the changes as it included adding return types to almost every controller method.
- Level 8 added a few `@var` tags and `@property` tags.