### PR TITLE
Road to test coverage

### DIFF
--- a/tests/Feature/AcceptVerificationRequestTest.php
+++ b/tests/Feature/AcceptVerificationRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Actions\AcceptVerificationRequest;
 use App\Http\Controllers\PublicProfileController;

--- a/tests/Feature/ArgumentTest.php
+++ b/tests/Feature/ArgumentTest.php
@@ -66,6 +66,13 @@ class ArgumentTest extends TestCase
             ->assertSet('isConfirmingDelete', null)
             ->assertOk();
 
+        Livewire::test(ArgumentList::class, ['rfc' => $rfc, 'user' => $user])
+            ->call('deleteArgument', $arguments[1]->id)
+            ->assertNotSet('isConfirmingDelete', null)
+            ->call('deleteArgument', $arguments[1]->id)
+            ->assertSet('isConfirmingDelete', null)
+            ->assertOk();
+
         $this->assertTrue($user->can('delete', $arguments[0]));
         $this->assertFalse($user->can('delete', $arguments[1]));
         $this->assertDatabaseCount('arguments', 1);

--- a/tests/Feature/CreateArgumentCommentTest.php
+++ b/tests/Feature/CreateArgumentCommentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Actions\CreateArgumentComment;
 use App\Models\Argument;

--- a/tests/Feature/CreateVerificationRequestTest.php
+++ b/tests/Feature/CreateVerificationRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Actions\CreateVerificationRequest;
 use App\Http\Controllers\VerificationRequestsAdminController;

--- a/tests/Feature/DenyVerificationRequestTest.php
+++ b/tests/Feature/DenyVerificationRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Actions\DenyVerificationRequest;
 use App\Http\Controllers\ProfileController;

--- a/tests/Feature/NewRfcMailTest.php
+++ b/tests/Feature/NewRfcMailTest.php
@@ -2,9 +2,11 @@
 
 namespace Feature;
 
+use App\Actions\SendUserMail;
 use App\Mail\NewRfcMail;
 use App\Models\Rfc;
 use App\Models\User;
+use App\Models\UserMail;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
@@ -41,5 +43,69 @@ final class NewRfcMailTest extends TestCase
             'user_id' => $c->id,
             'mail_type' => NewRfcMail::class,
         ]);
+    }
+
+    public function test_it_wont_send_email_to_user_that_didnt_opt_in(): void
+    {
+        Mail::fake();
+
+        $rfc = Rfc::factory()->create([
+            'title' => 'Test RFC',
+        ]);
+
+        $user = User::factory()->create(['email_optin' => false]);
+
+        (new SendUserMail)(
+            user: $user,
+            mailable: new NewRfcMail(
+                $rfc,
+                $user,
+            ),
+        );
+
+        $this->assertDatabaseMissing('user_mails', [
+            'user_id' => $user->id,
+            'mail_type' => NewRfcMail::class,
+        ]);
+
+        Mail::assertNothingOutgoing();
+    }
+
+    public function test_it_wont_send_email_to_user_that_has_already_gotten_it(): void
+    {
+        Mail::fake();
+
+        $rfc = Rfc::factory()->create([
+            'title' => 'Test RFC',
+        ]);
+
+        $user = User::factory()->create(['email_optin' => true]);
+
+        UserMail::factory()->create(['user_id' => $user->id, 'mail_type' => NewRfcMail::class]);
+
+        (new SendUserMail)(
+            user: $user,
+            mailable: new NewRfcMail(
+                $rfc,
+                $user,
+            ),
+        );
+
+        Mail::assertNothingOutgoing();
+    }
+
+    public function test_it_will_send_emails_for_multiple_created_rfcs(): void
+    {
+        Mail::fake();
+
+        User::factory()->create(['email_optin' => true]);
+
+        Rfc::factory()->count(3)->sequence(
+            ['title' => 'Test RFC 1',],
+            ['title' => 'Test RFC 2',],
+            ['title' => 'Test RFC 3',],
+        )->create();
+
+        Mail::assertSentCount(3);
     }
 }

--- a/tests/Feature/NewRfcMailTest.php
+++ b/tests/Feature/NewRfcMailTest.php
@@ -101,9 +101,9 @@ final class NewRfcMailTest extends TestCase
         User::factory()->create(['email_optin' => true]);
 
         Rfc::factory()->count(3)->sequence(
-            ['title' => 'Test RFC 1',],
-            ['title' => 'Test RFC 2',],
-            ['title' => 'Test RFC 3',],
+            ['title' => 'Test RFC 1'],
+            ['title' => 'Test RFC 2'],
+            ['title' => 'Test RFC 3'],
         )->create();
 
         Mail::assertSentCount(3);

--- a/tests/Feature/NewRfcMailTest.php
+++ b/tests/Feature/NewRfcMailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Actions\SendUserMail;
 use App\Mail\NewRfcMail;

--- a/tests/Feature/Profile/ProfileInformationTest.php
+++ b/tests/Feature/Profile/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Profile;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -26,11 +27,29 @@ class ProfileInformationTest extends TestCase
     {
         $this->actingAs($user = User::factory()->create());
 
+        $file = UploadedFile::fake()->image('avatar.png');
+
         Livewire::test(UpdateProfileInformationForm::class)
             ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
+            ->set('photo', $file)
             ->call('updateProfileInformation');
 
         $this->assertEquals('Test Name', $user->fresh()->name);
         $this->assertEquals('test@example.com', $user->fresh()->email);
+        $this->assertNotNull($user->fresh()->profile_photo_path);
+    }
+
+    public function test_profile_update_force_full(): void
+    {
+        $this->actingAs($user = User::factory()->create());
+
+        $originalEmail = $user->email;
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', ['name' => 'Test Name', 'email' => $originalEmail])
+            ->call('updateProfileInformation');
+
+        $this->assertEquals('Test Name', $user->fresh()->name);
+        $this->assertEquals($originalEmail, $user->fresh()->email);
     }
 }

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -19,8 +19,6 @@ class RegistrationTest extends TestCase
     {
         if (! Features::enabled(Features::registration())) {
             $this->markTestSkipped('Registration support is not enabled.');
-
-            return;
         }
 
         $response = $this->get('/register');

--- a/tests/Feature/RfcDetailTest.php
+++ b/tests/Feature/RfcDetailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use App\Http\Controllers\RfcDetailController;
 use App\Models\Rfc;

--- a/tests/Unit/GenerateUsernameActionTest.php
+++ b/tests/Unit/GenerateUsernameActionTest.php
@@ -8,14 +8,14 @@ use Tests\TestCase;
 
 class GenerateUsernameActionTest extends TestCase
 {
-	public function test_username_generation_for_user(): void
-	{
+    public function test_username_generation_for_user(): void
+    {
         $user = User::factory()->create(['name' => 'John Doe']);
 
         $username = (new GenerateUsername)($user);
 
         $this->assertEquals('john-doe', $username);
-	}
+    }
 
     public function test_username_generation_for_string(): void
     {

--- a/tests/Unit/GenerateUsernameActionTest.php
+++ b/tests/Unit/GenerateUsernameActionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Actions\GenerateUsername;
+use App\Models\User;
+use Tests\TestCase;
+
+class GenerateUsernameActionTest extends TestCase
+{
+	public function test_username_generation_for_user(): void
+	{
+        $user = User::factory()->create(['name' => 'John Doe']);
+
+        $username = (new GenerateUsername)($user);
+
+        $this->assertEquals('john-doe', $username);
+	}
+
+    public function test_username_generation_for_string(): void
+    {
+        $username = (new GenerateUsername)('one two three');
+
+        $this->assertEquals('one-two-three', $username);
+    }
+}

--- a/tests/Unit/RequestEmailChangeActionTest.php
+++ b/tests/Unit/RequestEmailChangeActionTest.php
@@ -11,8 +11,8 @@ use Tests\TestCase;
 
 class RequestEmailChangeActionTest extends TestCase
 {
-	public function test_request_change()
-	{
+    public function test_request_change()
+    {
         Mail::fake();
 
         $user = User::factory()->create();
@@ -25,6 +25,6 @@ class RequestEmailChangeActionTest extends TestCase
             'new_email' => $newEmail,
         ]);
 
-        Mail::assertSent(EmailVerificationMail::class, fn(EmailVerificationMail $mail) => $mail->hasTo($newEmail));
-	}
+        Mail::assertSent(EmailVerificationMail::class, fn (EmailVerificationMail $mail) => $mail->hasTo($newEmail));
+    }
 }

--- a/tests/Unit/RequestEmailChangeActionTest.php
+++ b/tests/Unit/RequestEmailChangeActionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Actions\RequestEmailChange;
+use App\Mail\EmailVerificationMail;
+use App\Models\EmailChangeRequest;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class RequestEmailChangeActionTest extends TestCase
+{
+	public function test_request_change()
+	{
+        Mail::fake();
+
+        $user = User::factory()->create();
+        $newEmail = 'new@email.com';
+
+        (new RequestEmailChange)($user, $newEmail);
+
+        $this->assertDatabaseHas(EmailChangeRequest::class, [
+            'user_id' => $user->id,
+            'new_email' => $newEmail,
+        ]);
+
+        Mail::assertSent(EmailVerificationMail::class, fn(EmailVerificationMail $mail) => $mail->hasTo($newEmail));
+	}
+}

--- a/tests/Unit/SendUserMessageActionTest.php
+++ b/tests/Unit/SendUserMessageActionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Actions\SendUserMessage;
+use App\Models\Message;
+use App\Models\User;
+use Tests\TestCase;
+
+class SendUserMessageActionTest extends TestCase
+{
+	public function test_it_wont_send_a_message_from_the_same_user_to_the_same_user()
+	{
+		$user = User::factory()->create();
+
+        (new SendUserMessage)($user, $user, '/test', 'Test');
+
+        $this->assertDatabaseMissing(Message::class, [
+            'user_id' => $user->id,
+            'sender_id' => $user->id,
+        ]);
+	}
+}

--- a/tests/Unit/SendUserMessageActionTest.php
+++ b/tests/Unit/SendUserMessageActionTest.php
@@ -9,9 +9,9 @@ use Tests\TestCase;
 
 class SendUserMessageActionTest extends TestCase
 {
-	public function test_it_wont_send_a_message_from_the_same_user_to_the_same_user()
-	{
-		$user = User::factory()->create();
+    public function test_it_wont_send_a_message_from_the_same_user_to_the_same_user()
+    {
+        $user = User::factory()->create();
 
         (new SendUserMessage)($user, $user, '/test', 'Test');
 
@@ -19,5 +19,5 @@ class SendUserMessageActionTest extends TestCase
             'user_id' => $user->id,
             'sender_id' => $user->id,
         ]);
-	}
+    }
 }

--- a/tests/Unit/ToggleArgumentVoteActionTest.php
+++ b/tests/Unit/ToggleArgumentVoteActionTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 
 use App\Actions\ToggleArgumentVote;
 use App\Models\Argument;
-use App\Models\ArgumentVote;
 use App\Models\ReputationType;
 use App\Models\User;
 use App\Models\VoteType;
@@ -12,9 +11,9 @@ use Tests\TestCase;
 
 class ToggleArgumentVoteActionTest extends TestCase
 {
-	public function test_it_toggle_argument_vote(): void
-	{
-		$user = User::factory()->create();
+    public function test_it_toggle_argument_vote(): void
+    {
+        $user = User::factory()->create();
         $argument = Argument::factory()->create(['vote_type' => VoteType::YES]);
 
         (new ToggleArgumentVote)($user, $argument);
@@ -34,5 +33,5 @@ class ToggleArgumentVoteActionTest extends TestCase
         ]);
         $this->assertEquals(0, $argument->vote_count);
         $this->assertEquals(0, $argument->rfc->count_yes);
-	}
+    }
 }

--- a/tests/Unit/ToggleArgumentVoteActionTest.php
+++ b/tests/Unit/ToggleArgumentVoteActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Actions\ToggleArgumentVote;
+use App\Models\Argument;
+use App\Models\ArgumentVote;
+use App\Models\ReputationType;
+use App\Models\User;
+use App\Models\VoteType;
+use Tests\TestCase;
+
+class ToggleArgumentVoteActionTest extends TestCase
+{
+	public function test_it_toggle_argument_vote(): void
+	{
+		$user = User::factory()->create();
+        $argument = Argument::factory()->create(['vote_type' => VoteType::YES]);
+
+        (new ToggleArgumentVote)($user, $argument);
+
+        $this->assertDatabaseHas('users', [
+            'reputation' => $user->reputation
+                + ReputationType::VOTE_FOR_ARGUMENT->getPoints(),
+        ]);
+        $this->assertEquals(1, $argument->vote_count);
+        $this->assertEquals(1, $argument->rfc->count_yes);
+
+        (new ToggleArgumentVote)($user->fresh(), $argument);
+
+        $this->assertDatabaseHas('users', [
+            'reputation' => $user->reputation
+                - ReputationType::VOTE_FOR_ARGUMENT->getPoints(),
+        ]);
+        $this->assertEquals(0, $argument->vote_count);
+        $this->assertEquals(0, $argument->rfc->count_yes);
+	}
+}


### PR DESCRIPTION
This PR improves test coverage for actions:
<img width="375" alt="image" src="https://github.com/brendt/rfc-vote/assets/17316322/335ab201-5408-48f9-a2f9-487e1c057580">

Also discovered a bug in application logic regarding new RFC emails. Currently user will only get 1 email regardless of how many RFC's have been created because `hasGottenEmail()` only checks for mail type, not if they received email for this new RFC. I have created a failing test for this case.
```php
public function hasGottenMail(Mailable $mailable): bool
{
    return $this->mails()->where('mail_type', $mailable::class)->exists();
}
```