### PR TITLE
Automatically fill Github URL

### DIFF
--- a/app/Http/Controllers/SocialiteCallbackController.php
+++ b/app/Http/Controllers/SocialiteCallbackController.php
@@ -26,7 +26,8 @@ final readonly class SocialiteCallbackController
             $user = User::create([
                 'email' => $socialiteUser->getEmail(),
                 'name' => $socialiteUser->getName() ?? $socialiteUser->getEmail(),
-                'username' => $this->resolveUsername($socialiteUser),
+                'username' => $username = $this->resolveUsername($socialiteUser),
+                'github_url' => $this->resolveGithubUrl($username),
                 'reputation' => 0,
                 'socialite' => serialize($socialiteUser),
             ]);
@@ -43,6 +44,11 @@ final readonly class SocialiteCallbackController
         $request->session()->regenerate();
 
         return redirect()->to('/');
+    }
+
+    protected function resolveGithubUrl(string $username): string
+    {
+        return "https://github.com/$username";
     }
 
     private function resolveUsername(SocialiteUser $socialiteUser): string

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -3,12 +3,17 @@
 namespace Tests\Feature;
 
 use App\Actions\GenerateUsername;
+use App\Http\Controllers\SocialiteCallbackController;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
+use Laravel\Socialite\Contracts\Factory as SocialiteFactory;
+use Laravel\Socialite\Two\GithubProvider;
+use Mockery;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
@@ -79,6 +84,28 @@ class RegistrationTest extends TestCase
     public function test_registration_form_contains_username_component(): void
     {
         $this->get('/register')->assertSeeLivewire('username-input');
+    }
+
+    public function test_github_registration_fills_github_url(): void
+    {
+        $this->mock(SocialiteFactory::class, function (MockInterface $mock) {
+            $mockUser = tap(new \Laravel\Socialite\Two\User())->map([
+                'email' => 'foo@bar.com',
+                'name' => 'Brent Roose',
+                'nickname' => 'brendt',
+            ]);
+
+            $mockedDriver = Mockery::mock(GithubProvider::class);
+            $mockedDriver->shouldReceive('user')->andReturn($mockUser);
+
+            $mock->shouldReceive('driver')->with('github')->andReturn($mockedDriver);
+        });
+
+        $this->get(action(SocialiteCallbackController::class, ['driver' => 'github', 'code' => 200]));
+
+        $this->assertDatabaseHas(User::class, [
+            'github_url' => 'https://github.com/brendt',
+        ]);
     }
 
     public static function validationDataProvider(): array


### PR DESCRIPTION
The PR adds functionality to auto-fill the User's `github_url` when registering with a Github account.

