### PR TITLE
Only use `composer install` in CI

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -47,8 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer install
           npm install
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -52,8 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer install
           npm install
 
       - name: List Installed Dependencies


### PR DESCRIPTION
This is an application and not a package, so it doesn't make sense to do any composer updates in CI. We're committing `composer.lock` so we should always use the same dependencies.