### PR TITLE
Extract `getContributors` to a support class 

### DIFF
--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -2,46 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Contributor;
+use App\Support\FetchContributors;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\File;
-use JsonException;
 
 final readonly class AboutController
 {
-    private const DAY = 60 * 60 * 24;
-
-    public function __invoke(): View
+    public function __invoke(FetchContributors $contributors): View
     {
-        $contributors = Cache::remember('contributors', self::DAY, $this->getContributors(...));
+        $contributors = Cache::remember('contributors', now()->addDay(), $contributors->getContributors(...));
 
         shuffle($contributors);
 
         return view('about', compact('contributors'));
-    }
-
-    /**
-     * @return Contributor[]
-     *
-     * @throws JsonException
-     */
-    private function getContributors(): array
-    {
-        /**
-         * @var array{
-         *     contributors: array<int, array{
-         *         id: int,
-         *         name: string,
-         *         url: string,
-         *         contributions: array<int, string>,
-         *     }>
-         * } $contributors
-         */
-        $contributors = File::json(__DIR__.'/../../../contributors.json', JSON_THROW_ON_ERROR);
-
-        return collect($contributors['contributors'])
-            ->map(fn (array $contributor) => new Contributor(...$contributor))
-            ->all();
     }
 }

--- a/app/Support/FetchContributors.php
+++ b/app/Support/FetchContributors.php
@@ -23,7 +23,7 @@ class FetchContributors
      *     name: string,
      *     url: string,
      *     contributions: array<int, string>,
-     * }
+     * }>
      */
     public function getJson(): array
     {

--- a/app/Support/FetchContributors.php
+++ b/app/Support/FetchContributors.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Contributor;
+use Illuminate\Support\Facades\File;
+
+class FetchContributors
+{
+    /**
+     * @return array<int, Contributor>
+     */
+    public function getContributors(): array
+    {
+        return collect($this->getJson())
+            ->map(fn (array $contributor) => new Contributor(...$contributor))
+            ->all();
+    }
+
+    /**
+     * @return array<int, array{
+     *     id: int,
+     *     name: string,
+     *     url: string,
+     *     contributions: array<int, string>,
+     * }
+     */
+    public function getJson(): array
+    {
+        $contributors = File::json(base_path('contributors.json'), JSON_THROW_ON_ERROR);
+
+        return $contributors['contributors'] ?? [];
+    }
+}

--- a/tests/Feature/AboutTest.php
+++ b/tests/Feature/AboutTest.php
@@ -22,7 +22,6 @@ class AboutTest extends TestCase
         ];
 
         $this->mock(FetchContributors::class, function (MockInterface $mock) use ($contributors) {
-            $mock->shouldReceive('getJson')->andReturn([]);
             $mock->shouldReceive('getContributors')->andReturn($contributors);
         });
 

--- a/tests/Feature/AboutTest.php
+++ b/tests/Feature/AboutTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\AboutController;
+use App\Models\Contributor;
+use App\Support\FetchContributors;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class AboutTest extends TestCase
+{
+    public function test_it_has_contributors(): void
+    {
+        $contributors = [
+            new Contributor(...[
+                'id' => 6905297,
+                'name' => 'Brent',
+                'url' => 'https://github.com/brendt',
+                'contributions' => ['Frontend', 'Backend'],
+            ]),
+        ];
+
+        $this->mock(FetchContributors::class, function (MockInterface $mock) use ($contributors) {
+            $mock->shouldReceive('getJson')->andReturn([]);
+            $mock->shouldReceive('getContributors')->andReturn($contributors);
+        });
+
+        $response = $this->get(action(AboutController::class));
+        $response->assertStatus(200);
+        $response->assertViewHas('contributors', $contributors);
+    }
+}

--- a/tests/Feature/Support/FetchContributorsTest.php
+++ b/tests/Feature/Support/FetchContributorsTest.php
@@ -2,26 +2,28 @@
 
 namespace Tests\Feature\Support;
 
+use App\Models\Contributor;
 use App\Support\FetchContributors;
 use Illuminate\Support\Arr;
 use Tests\TestCase;
 
 class FetchContributorsTest extends TestCase
 {
-    protected array $contributors;
 
     public function test_no_duplicates_in_contributors_json()
     {
+        $contributors = app(FetchContributors::class)->getJson();
+
         $this->assertCount(0,
-            $duplicates = collect($this->contributors)->duplicates('id'),
+            $duplicates = collect($contributors)->duplicates('id'),
             sprintf('ID %s is in contributors.json more than once.', Arr::first($duplicates))
         );
     }
 
-    protected function setUp(): void
+    public function test_get_contributors_returns_an_array_of_contributor_models()
     {
-        parent::setUp();
+        $contributors = app(FetchContributors::class)->getContributors();
 
-        $this->contributors = app(FetchContributors::class)->getJson();
+        $this->assertCount(0, collect($contributors)->reject(fn ($contributor) => $contributor instanceof Contributor));
     }
 }

--- a/tests/Feature/Support/FetchContributorsTest.php
+++ b/tests/Feature/Support/FetchContributorsTest.php
@@ -23,6 +23,6 @@ class FetchContributorsTest extends TestCase
     {
         $contributors = app(FetchContributors::class)->getContributors();
 
-        $this->assertCount(0, collect($contributors)->reject(fn ($contributor) => $contributor instanceof Contributor));
+        $this->assertContainsOnlyInstancesOf(Contributor::class, $contributors);
     }
 }

--- a/tests/Feature/Support/FetchContributorsTest.php
+++ b/tests/Feature/Support/FetchContributorsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Support;
+
+use App\Support\FetchContributors;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class FetchContributorsTest extends TestCase
+{
+    protected array $contributors;
+
+    public function test_no_duplicates_in_contributors_json()
+    {
+        $this->assertCount(0,
+            $duplicates = collect($this->contributors)->duplicates('id'),
+            sprintf('ID %s is in contributors.json more than once.', Arr::first($duplicates))
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contributors = app(FetchContributors::class)->getJson();
+    }
+}


### PR DESCRIPTION
closes #240

This PR extract the `getContributors` method from the `AboutController` to a support class so it can be mocked and used elsewhere if needed.