### PR TITLE
Improve test coverage

### DIFF
--- a/app/Console/Commands/RfcSyncCommand.php
+++ b/app/Console/Commands/RfcSyncCommand.php
@@ -3,10 +3,9 @@
 namespace App\Console\Commands;
 
 use App\Models\Rfc;
-use Feed;
+use App\Support\ExternalsRssFeed;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
-use SimpleXMLElement;
 
 class RfcSyncCommand extends Command
 {
@@ -14,10 +13,14 @@ class RfcSyncCommand extends Command
 
     protected $description = 'Sync RFCs from Externals RSS feed';
 
-    public function handle(): void
+    public function __construct(private readonly ExternalsRssFeed $feed)
     {
-        /** @var SimpleXMLElement $rss */
-        $rss = Feed::loadRss('https://externals.io/rss');
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $rss = $this->feed->load();
 
         foreach ($rss->item as $item) {
             if (! Str::startsWith((string) ($item->title ?? null), ['[VOTE]'])) {
@@ -36,5 +39,7 @@ class RfcSyncCommand extends Command
                 $this->comment("\t{$url}");
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,6 +8,9 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 class Kernel extends ConsoleKernel
 {
+    /**
+     * @codeCoverageIgnore part of Laravel framework, no need to test
+     */
     protected function schedule(Schedule $schedule): void
     {
         $schedule->command(RfcSyncCommand::class)->hourly();

--- a/app/Support/ExternalsRssFeed.php
+++ b/app/Support/ExternalsRssFeed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Support;
+
+use Feed;
+use SimpleXMLElement;
+
+/**
+ * @codeCoverageIgnore this is a wrapper for `Feed::loadRss`, cannot be tested
+ */
+class ExternalsRssFeed
+{
+    public function load(): SimpleXMLElement
+    {
+        /** @var SimpleXMLElement $rss */
+        $rss = Feed::loadRss('https://externals.io/rss');
+
+        return $rss;
+    }
+}

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -4,13 +4,10 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_login_screen_can_be_rendered(): void
     {
         $response = $this->get('/login');

--- a/tests/Feature/BrowserSessionsTest.php
+++ b/tests/Feature/BrowserSessionsTest.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 
 class BrowserSessionsTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_other_browser_sessions_can_be_logged_out(): void
     {
         $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/DeleteAccountTest.php
+++ b/tests/Feature/DeleteAccountTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
@@ -11,8 +10,6 @@ use Tests\TestCase;
 
 class DeleteAccountTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_user_accounts_can_be_deleted(): void
     {
         if (! Features::hasAccountDeletionFeatures()) {

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
@@ -13,8 +12,6 @@ use Tests\TestCase;
 
 class EmailVerificationTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_email_verification_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::emailVerification())) {

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -3,13 +3,10 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
 
 class HomeTest extends TestCase
 {
-    use LazilyRefreshDatabase;
-
     public function test_the_application_returns_a_successful_response(): void
     {
         $this->get('/')->assertStatus(200);

--- a/tests/Feature/PasswordConfirmationTest.php
+++ b/tests/Feature/PasswordConfirmationTest.php
@@ -3,13 +3,10 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class PasswordConfirmationTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_confirm_password_screen_can_be_rendered(): void
     {
         $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -4,15 +4,12 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class PasswordResetTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_reset_password_link_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {

--- a/tests/Feature/Profile/ProfileInformationTest.php
+++ b/tests/Feature/Profile/ProfileInformationTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Profile;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
@@ -11,8 +10,6 @@ use Tests\TestCase;
 
 class ProfileInformationTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_current_profile_information_is_available(): void
     {
         $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/Profile/UpdateProfileTest.php
+++ b/tests/Feature/Profile/UpdateProfileTest.php
@@ -4,15 +4,12 @@ namespace Tests\Feature\Profile;
 
 use App\Http\Controllers\ProfileController;
 use App\Models\User;
-use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class UpdateProfileTest extends TestCase
 {
-    use LazilyRefreshDatabase;
-
     private string $url;
 
     public function setUp(): void

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -6,7 +6,6 @@ use App\Actions\GenerateUsername;
 use App\Http\Controllers\SocialiteCallbackController;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
@@ -18,8 +17,6 @@ use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_registration_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::registration())) {

--- a/tests/Feature/RfcTest.php
+++ b/tests/Feature/RfcTest.php
@@ -10,13 +10,12 @@ use App\Http\Controllers\RfcEditController;
 use App\Http\Controllers\RfcMetaImageController;
 use App\Models\Rfc;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class RfcTest extends TestCase
 {
-    use RefreshDatabase, WithFaker;
+    use WithFaker;
 
     /** @test */
     public function rfc_management_only_accessible_by_admin()

--- a/tests/Feature/TwoFactorAuthenticationSettingsTest.php
+++ b/tests/Feature/TwoFactorAuthenticationSettingsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
@@ -11,14 +10,10 @@ use Tests\TestCase;
 
 class TwoFactorAuthenticationSettingsTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_two_factor_authentication_can_be_enabled(): void
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/tests/Feature/UpdatePasswordTest.php
+++ b/tests/Feature/UpdatePasswordTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
@@ -11,8 +10,6 @@ use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase
 {
-    use RefreshDatabase;
-
     public function test_password_can_be_updated(): void
     {
         $this->actingAs($user = User::factory()->create());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Spatie\Browsershot\Browsershot;
 
@@ -12,7 +12,7 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use DatabaseMigrations;
-    use RefreshDatabase;
+    use LazilyRefreshDatabase;
 
     protected function setUp(): void
     {

--- a/tests/Unit/RfcSyncCommandTest.php
+++ b/tests/Unit/RfcSyncCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\RfcSyncCommand;
+use App\Support\ExternalsRssFeed;
+use Mockery\MockInterface;
+use SimpleXMLElement;
+use Tests\TestCase;
+
+class RfcSyncCommandTest extends TestCase
+{
+    public function test_command(): void
+    {
+        $this->mock(ExternalsRssFeed::class, function (MockInterface $mock) {
+            $mock->shouldReceive('load')
+                ->once()
+                ->andReturn(new SimpleXMLElement(file_get_contents(base_path('tests/fixtures/externals.xml'))));
+        });
+
+        $this->artisan(RfcSyncCommand::class)->assertSuccessful();
+
+        $this->assertDatabaseHas('rfcs', [
+            'title' => '[VOTE] RFC Shorter attribute syntax change',
+            'url' => 'https://wiki.php.net/rfc/shorter_attribute_syntax_change',
+        ]);
+
+        $this->assertDatabaseHas('rfcs', [
+            'title' => '[VOTE] RFC Without url',
+            'url' => null,
+        ]);
+
+        $this->assertDatabaseMissing('rfcs', [
+            'title' => 'RFC Should not include this',
+        ]);
+    }
+}

--- a/tests/fixtures/externals.xml
+++ b/tests/fixtures/externals.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<channel>
+    <item>
+        <title>[VOTE] RFC Shorter attribute syntax change</title>
+        <link>https://externals.io/message/120946</link>
+        <description>"https://wiki.php.net/rfc/shorter_attribute_syntax_change"</description>
+    </item>
+    <item>
+        <title>RFC Should not include this</title>
+        <link>https://externals.io/message/120946</link>
+        <description>"https://wiki.php.net/rfc/should_not_include_this_rfc"</description>
+    </item>
+    <item>
+        <title>[VOTE] RFC Without url</title>
+        <link>https://externals.io/message/120946</link>
+        <description>Description without url</description>
+    </item>
+</channel>


### PR DESCRIPTION
This PR improves coverage for `app/Console`
<img width="298" alt="image" src="https://github.com/brendt/rfc-vote/assets/17316322/c9f3934a-3b08-4abf-aab3-047d25bdd081">

* Implemented `ExternalsRssFeed` class that acts as a wrapper for `Feed` which can be mocked in tests.
* Added `@codeCoverageIgnore` to `Kernel::schedule()` as it's part of Laravel and doesn't need testing.
* Added `@codeCoverageIgnore` to `ExternalsRssFeed` as it's a wrapper which is mocked in tests.
* Removed `RefreshDatabase` trait from tests in favor of `LazilyRefreshDatabase` on `TestCase`.