### PR TITLE
Adds full date tooltip to relative dates

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -125,6 +125,12 @@
             "name": "Vytautas",
             "url": "https://github.com/Plytas",
             "contributions": ["Backend"]
+        },
+        {
+            "id": 8448512,
+            "name": "MoeBrowne",
+            "url": "https://github.com/moebrowne",
+            "contributions": ["Backend"]
         }
     ]
 }

--- a/resources/views/api/api-token-manager.blade.php
+++ b/resources/views/api/api-token-manager.blade.php
@@ -71,7 +71,11 @@
                                 <div class="flex items-center ml-2">
                                     @if ($token->last_used_at)
                                         <div class="text-sm text-gray-400">
-                                            {{ __('Last used') }} {{ $token->last_used_at->diffForHumans() }}
+                                            {{ __('Last used') }}
+
+                                            <time datetime="{{ $token->last_used_at->format('c') }}" title="{{ $token->last_used_at->format('c') }}">
+                                                {{ $token->last_used_at->diffForHumans() }}
+                                            </time>
                                         </div>
                                     @endif
 

--- a/resources/views/components/argument-card/card-footer.blade.php
+++ b/resources/views/components/argument-card/card-footer.blade.php
@@ -43,9 +43,11 @@
         <span class="hidden md:block">•</span>
 
         {{-- Label that shows when argument has been created --}}
-        <small title="{{ __('Argument creation date') }}">
-            <span class="md:hidden">{{ __('Created') }}</span>
-            {{ $argument->created_at->diffForHumans() }}
-        </small>
+        <time datetime="{{ $argument->created_at->format('c') }}" title="{{ $argument->created_at->format('c') }}">
+            <small>
+                <span class="md:hidden">{{ __('Created') }}</span>
+                {{ $argument->created_at->diffForHumans() }}
+            </small>
+        </time>
     </div>
 </div>

--- a/resources/views/components/profile/header.blade.php
+++ b/resources/views/components/profile/header.blade.php
@@ -24,7 +24,11 @@
             </h2>
 
             <p class="text-font-second">
-                {{ __('Member since') }} {{ $user->created_at->diffForHumans() }}
+                {{ __('Member since') }}
+
+                <time datetime="{{ $user->created_at->format('c') }}" title="{{ $user->created_at->format('c') }}">
+                    {{ $user->created_at->diffForHumans() }}
+                </time>
             </p>
 
             <x-profile.social :user="$user" />


### PR DESCRIPTION
Anywhere that `$time->diffForHumans()` is presented to the user it is common to add a tool tip showing the absolute date.