### PR TITLE
Improved RFC faking

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -125,6 +125,12 @@
             "name": "Vytautas",
             "url": "https://github.com/Plytas",
             "contributions": ["Backend"]
+        },
+        {
+            "id": 8448512,
+            "name": "MoeBrowne",
+            "url": "https://github.com/moebrowne",
+            "contributions": ["Backend"]
         }
     ]
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -42,10 +42,16 @@ class DatabaseSeeder extends Seeder
             ]);
         }
 
-        $rfcs = Rfc::factory()->count(10)->create([
-            'title' => 'Interface Default Methods',
-            'published_at' => now()->subDay(),
-        ]);
+        $rfcs = Rfc::factory()
+            ->count(3)
+            ->sequence(
+                ['title' => 'The Pipe Operator'],
+                ['title' => 'Short Closures 2.0'],
+                ['title' => 'Interface Default Methods'],
+            )
+            ->create([
+                'published_at' => now()->subDay(),
+            ]);
 
         foreach ($rfcs as $rfc) {
             $majority = fake()->boolean() ? VoteType::YES : VoteType::NO;


### PR DESCRIPTION
This PR adds names to faked RFCs. The number of fake RFCs is also reduced to 3 which matches the number hard-coded to show in the RFC list. This improves seeding performance