### PR TITLE
Adds escaping to markdown parser

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -28,7 +28,10 @@ return [
      *
      * More info: https://spatie.be/docs/laravel-markdown/v1/using-the-blade-component/passing-options-to-commonmark
      */
-    'commonmark_options' => [],
+    'commonmark_options' => [
+        'html_input' => 'escape',
+        'allow_unsafe_links' => false,
+    ],
 
     /*
      * Rendering markdown to HTML can be resource intensive. By default


### PR DESCRIPTION
This PR configures the commonmark parser to escape HTML content to prevent XSS.

See https://commonmark.thephpleague.com/2.4/security/ for details