### PR TITLE
Added message when no arguments

### DIFF
--- a/resources/views/publicProfile.blade.php
+++ b/resources/views/publicProfile.blade.php
@@ -5,7 +5,7 @@
 
         <div class="grid gap-4 mt-6">
             <h2 class="text-3xl font-bold text-font">
-                {{ __('Arguments and votes') }}
+                Arguments and votes
             </h2>
 
             @foreach ($user->argumentVotes->pluck('argument')->sortByDesc('created_at') as $argument)

--- a/resources/views/publicProfile.blade.php
+++ b/resources/views/publicProfile.blade.php
@@ -10,9 +10,6 @@
 
             @foreach ($user->argumentVotes->pluck('argument')->sortByDesc('created_at') as $argument)
                 <div class="grid gap-2">
-{{--                    <a class="px-2 underline hover:no-underline text-lg font-bold" href="{{ action(\App\Http\Controllers\RfcDetailController::class, $argument->rfc) }}">--}}
-{{--                        {{ $argument->rfc->title }}--}}
-{{--                    </a>--}}
                     <x-argument-card.card
                         :user="$user"
                         :rfc="$argument->rfc"

--- a/resources/views/publicProfile.blade.php
+++ b/resources/views/publicProfile.blade.php
@@ -8,7 +8,7 @@
                 Arguments and votes
             </h2>
 
-            @foreach ($user->argumentVotes->pluck('argument')->sortByDesc('created_at') as $argument)
+            @forelse ($user->argumentVotes->pluck('argument')->sortByDesc('created_at') as $argument)
                 <div class="grid gap-2">
                     <x-argument-card.card
                         :user="$user"
@@ -17,7 +17,11 @@
                         :readonly="true"
                     />
                 </div>
-            @endforeach
+            @empty
+                <h2 class="text-xl text-font opacity-70">
+                    {{ $user->name }} doesn't have any arguments yet
+                </h2>
+            @endforelse
         </div>
     </div>
 

--- a/resources/views/publicProfile.blade.php
+++ b/resources/views/publicProfile.blade.php
@@ -1,3 +1,9 @@
+@php
+    /**
+     * @var App\Models\User $user
+     */
+@endphp
+
 @component('layouts.base')
 
     <div class="container mx-auto px-4 mt-8 md:mt-12 max-w-[1200px] mb-8">


### PR DESCRIPTION
Added message `{{ $user->name }} doesn't have any arguments yet` to user profile arguments. Before it was just an empty space like this:

### Before
<img width="1337" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/fbaead75-308f-4115-bb1d-2cea4bd4172d">

Now, it will be a message:

### After
<img width="1319" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/a0411ec6-7cce-4648-b744-bcd035a33e02">

I've made use of Blade's `@forelse`:

```php
@forelse ($array as $item)
    // when not empty
@empty
    // when empty
@endforelse
```