### PR TITLE
Fixed text that was black on dark background

### DIFF
--- a/resources/views/livewire/message-list.blade.php
+++ b/resources/views/livewire/message-list.blade.php
@@ -7,7 +7,7 @@
         @endforeach
 
         @if($user->inboxMessages->isEmpty())
-            <p>Inbox 0!</p>
+            <p class="text-lg opacity-60 text-font">There are not messages yet!</p>
         @endif
 
         @if($user->archivedMessages->isNotEmpty())


### PR DESCRIPTION
It happened when the dark theme was enabled on the messages page.

## Before
<img width="246" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/476b971a-1560-4b31-a74f-c32646c9ddae">

## Now
<img width="358" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/8379e654-8416-4757-95e6-5e01ef783c81">

>Also change the message a bit from `Inbox 0` to `There are not messages yet!`.