### PR TITLE
Moved 'Add a new comment' title to a comment-form.blade.php component

### DIFF
--- a/resources/views/argument-comments.blade.php
+++ b/resources/views/argument-comments.blade.php
@@ -42,11 +42,7 @@
                 @endforeach
             </div>
 
-            <div class="mt-6  md:mt-8">
-                <h2 class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-white opacity-80 mb-2">
-                    Add a new comment
-                </h2>
-
+            <div class="mt-6 md:mt-8">
                 <x-argument-card.comment-form
                     :user="$user"
                     :argument="$argument"

--- a/resources/views/components/argument-card/comment-form.blade.php
+++ b/resources/views/components/argument-card/comment-form.blade.php
@@ -9,6 +9,9 @@
     </div>
 
     <div class="w-full">
+        <h2 class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-white opacity-80 mb-2">
+            Add a new comment
+        </h2>
 
         <form method="post" action="{{ action(\App\Http\Controllers\CreateArgumentCommentController::class, $argument) }}">
             @csrf


### PR DESCRIPTION
related #268

Moved `Add a new comment` title to a `comment-form.blade.php` component. Just to make so that the title is not over the avatar but over the form:

![image](https://github.com/brendt/rfc-vote/assets/35465417/63aa12c7-b182-485f-bb19-f4a87bbd7770)
