### PR TITLE
Changed info message when you create comment

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -35,13 +35,9 @@
 <x-navbar.navbar :user="$user" />
 
 <div class="flex-1">
-    @if(flash()->message)
-        <div
-            class="container mx-auto px-4 mt-4 md:mt-12 max-w-[1200px] mb-8"
-        >
-            <div class="p-4 md:px-8 bg-blue-200 mb-4 md:mb-8 rounded-md md:rounded-full text-blue-900 font-bold">
-                {{ flash()->message }}
-            </div>
+    @if (flash()->message)
+        <div class="container mx-auto mt-6">
+            <x-success-message>{{ flash()->message }}</x-success-message>
         </div>
     @endif
 


### PR DESCRIPTION
Since we already have a `<x-success-message>` component that we use on different forms like login and register, I thought it's better to reuse it for success messages that we have in `base.blade.php` file.

![image](https://github.com/brendt/rfc-vote/assets/35465417/51a4cba7-c20a-4d94-82bc-5e737b2a37dc)

related #268
