### PR TITLE
Argument card style fixes

### DIFF
--- a/resources/views/components/argument-card/card.blade.php
+++ b/resources/views/components/argument-card/card.blade.php
@@ -10,7 +10,7 @@
 
 <div {{dusk('argument-card')}} id="{{ $anchorLink }}"
      @class([
-        'bg-argument-card text-font rounded-xl w-full group/card pt-5 pl-4 pr-10 md:px-8 md:pt-7 flex gap-6 items-center relative',
+        'bg-argument-card text-font rounded-xl w-full group/card pt-5 px-4 md:pl-8 md:pr-10 md:pt-7 flex flex-col md:flex-row gap-3 md:gap-6 items-center relative',
         'border-2 border-purple-300 dark:border-purple-800' => !$readonly && $user && !$user->hasSeenArgument($argument),
         'border border-divider' => !(!$readonly && $user && !$user->hasSeenArgument($argument)),
      ])
@@ -35,7 +35,7 @@
                     class="!bg-agree hover:!bg-agree-dark"
                 >
                     <span wire:loading wire:target="editArgument('{{ $argument->id }}')">
-                             <x-icons.loading  class="w-6 h-6"></x-icons.loading>
+                        <x-icons.loading  class="w-6 h-6"></x-icons.loading>
                     </span>
                     <span wire:loading.remove wire:target="editArgument('{{ $argument->id }}')">
                         <x-icons.check class="w-6 h-6" />

--- a/resources/views/components/argument-card/card.blade.php
+++ b/resources/views/components/argument-card/card.blade.php
@@ -41,7 +41,7 @@
                         <x-icons.check class="w-6 h-6" />
                     </span>
 
-                    {{ __('Save') }}
+                    Save
                 </x-buttons.main>
 
                 @if ($isConfirmingDelete?->is($argument))
@@ -50,7 +50,7 @@
                         class="!bg-disagree hover:!bg-disagree-dark"
                     >
                         <x-icons.cancel class="w-6 h-6" />
-                        {{ __('Cancel') }}
+                        Cancel
                     </x-buttons.main>
                 @else
                     <x-buttons.main
@@ -58,7 +58,7 @@
                         class="!bg-disagree hover:!bg-disagree-dark {{ empty($this->body) && $isEditing?->is($argument) ? 'cursor-not-allowed' : '' }}"
                     >
                         <x-icons.cancel class="w-6 h-6" />
-                        {{ __('Cancel') }}
+                        Cancel
                     </x-buttons.main>
                 @endif
             </div>

--- a/resources/views/components/argument-card/options.blade.php
+++ b/resources/views/components/argument-card/options.blade.php
@@ -48,10 +48,10 @@
                 class="!bg-agree hover:!bg-agree-dark"
             >
                 <span wire:loading wire:target="deleteArgument('{{ $argument->id }}')">
-                     <x-icons.loading  class="w-4 h-4"></x-icons.loading>
+                    <x-icons.loading class="w-4 h-4" />
                 </span>
                 <span wire:loading.remove wire:target="deleteArgument('{{ $argument->id }}')">
-                       <x-icons.check class="w-4 h-4" />
+                    <x-icons.check class="w-4 h-4" />
                 </span>
 
                 Yes!

--- a/resources/views/components/argument-card/options.blade.php
+++ b/resources/views/components/argument-card/options.blade.php
@@ -10,14 +10,10 @@
     class="absolute top-3 right-3 z-10 bg-argument-card"
     x-data="{ isVisible: false }"
 >
-    <button
-        type="button"
-        class="p-2 rounded-full group-hover:bg-gray-100"
+    <x-buttons.more-options
         @click="isVisible = !isVisible"
         @click.away="isVisible = false"
-    >
-        <x-icons.ellipsis-vertical class="w-7 h-7 text-font absolute right-0 top-0" />
-    </button>
+    />
 
     <div
         x-cloak

--- a/resources/views/components/argument-card/options.blade.php
+++ b/resources/views/components/argument-card/options.blade.php
@@ -25,7 +25,7 @@
                 wire:click="editArgument('{{ $argument->id }}')"
                 icon="icons.pen"
             >
-                {{ __('Edit') }}
+                Edit
             </x-argument-card.button>
         @endif
 
@@ -34,14 +34,14 @@
                 wire:click="deleteArgument('{{ $argument->id }}')"
                 icon="icons.trash"
             >
-                {{ __('Delete') }}
+                Delete
             </x-argument-card.button>
         @endif
     </div>
 
     @if ($isConfirmingDelete?->is($argument))
         <div class="absolute right-6 bg-argument-card flex flex-col gap-2 p-3 border rounded-sm min-w-[140px]">
-            <b>{{ __('Are you sure?') }}</b>
+            <b>Are you sure?</b>
 
             <x-buttons.main-small
                 wire:click="deleteArgument('{{ $argument->id }}')"
@@ -54,7 +54,7 @@
                        <x-icons.check class="w-4 h-4" />
                 </span>
 
-                {{ __('Yes') }}!
+                Yes!
             </x-buttons.main-small>
 
             <x-buttons.main-small
@@ -62,7 +62,7 @@
                 class="!bg-disagree hover:!bg-disagree-dark"
             >
                 <x-icons.cancel class="w-4 h-4" />
-                {{ __('No') }}!
+                No!
             </x-buttons.main-small>
         </div>
     @endif

--- a/resources/views/components/argument-card/vote.blade.php
+++ b/resources/views/components/argument-card/vote.blade.php
@@ -5,7 +5,7 @@
 <div
     class="
         {{ $user?->can('vote', $argument) ?  "cursor-pointer" : "cursor-not-allowed" }}
-        flex flex-col gap-1 transition-colors py-3 px-2 mb-5 max-w-[50px] mx-auto text-center rounded-2xl text-lg border border-transparent box-content
+        flex items-center md:flex-col gap-1 transition-colors py-1 md:py-3 px-3 md:px-2 md:mb-5 md:max-w-[50px] mx-auto text-center rounded-full md:rounded-2xl text-lg border border-transparent box-content
         @if ($argument->vote_type->isYes())
             text-agree-arrow
             bg-agree-arrow-background

--- a/resources/views/components/buttons/more-options.blade.php
+++ b/resources/views/components/buttons/more-options.blade.php
@@ -1,0 +1,14 @@
+@php
+    /**
+     * @var Illuminate\View\ComponentAttributeBag $attributes
+     */
+@endphp
+
+<button
+    {{ $attributes->merge([
+        'type' => 'button',
+        'class' => 'p-1 rounded-full group-hover:bg-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+    ]) }}
+>
+    <x-icons.ellipsis-vertical class="w-7 h-7 text-font" />
+</button>

--- a/resources/views/components/message-card/options.blade.php
+++ b/resources/views/components/message-card/options.blade.php
@@ -8,14 +8,10 @@
     class="absolute right-2 top-2"
     x-data="{ open: false }"
 >
-    <button
-        type="button"
-        class="p-1 rounded-full group-hover:bg-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+    <x-buttons.more-options
         @click="open = !open"
         @click.away="open = false"
-    >
-        <x-icons.ellipsis-vertical class="w-7 h-7 text-font" />
-    </button>
+    />
 
     <div
         x-cloak


### PR DESCRIPTION
## The problem
Argument cards look squashy on mobile with extra white space:

![image](https://github.com/brendt/rfc-vote/assets/35465417/66affa93-f50f-49cf-8b29-80b00d439a12)

## Solution
I want to move the upvote button to the top and change it to be horizontal:

![image](https://github.com/brendt/rfc-vote/assets/35465417/0ec6dbc1-e018-427d-b3ed-925ff655d449)

Now, the footer will be full width and the argument content in full width.