### PR TITLE
Changed the profile settings layout into 2 columns

### DIFF
--- a/resources/views/components/form/wrapper.blade.php
+++ b/resources/views/components/form/wrapper.blade.php
@@ -6,12 +6,14 @@
      */
 @endphp
 
-<form {{ $attributes->merge(['class' => 'bg-form mx-3 md:mx-0 p-8 rounded-lg shadow-md text-font']) }}>
-    @csrf
+<div>
+    <form {{ $attributes->merge(['class' => 'bg-form mx-3 md:mx-0 p-8 rounded-lg shadow-md text-font']) }}>
+        @csrf
 
-    @isset($heading)
-        <h2 class="text-2xl font-bold mb-4 text-font">{{ $heading }}</h2>
-    @endisset
+        @isset($heading)
+            <h2 class="text-2xl font-bold mb-4 text-font">{{ $heading }}</h2>
+        @endisset
 
-    {{ $slot }}
-</form>
+        {{ $slot }}
+    </form>
+</div>

--- a/resources/views/profile-form.blade.php
+++ b/resources/views/profile-form.blade.php
@@ -1,8 +1,12 @@
 @component('layouts.base')
-    <div class="grid mx-auto container max-w-[800px] px-4 gap-6 my-4 md:my-12">
-        <x-profile.settings.profile :user="$user" />
-        <x-profile.settings.email :user="$user" />
-        <x-profile.settings.password :user="$user" />
-        <x-profile.settings.verification :user="$user" />
+    <div class="grid grid-cols-1 lg:grid-cols-2 mx-auto container gap-6 my-4 md:my-10">
+        <div class="space-y-6">
+            <x-profile.settings.profile :user="$user" />
+            <x-profile.settings.email :user="$user" />
+        </div>
+        <div class="space-y-6">
+            <x-profile.settings.password :user="$user" />
+            <x-profile.settings.verification :user="$user" />
+        </div>
     </div>
 @endcomponent


### PR DESCRIPTION
Changed the profile settings layout into 2 columns to make use of that extra empty space.

## Before
![image](https://github.com/brendt/rfc-vote/assets/35465417/346fe21f-899b-4ccd-a79d-f3016a1f43c2)

## After
![image](https://github.com/brendt/rfc-vote/assets/35465417/20f67aa5-c831-4922-a20e-b96c1955bb77)

The mobile view is still the same, everything is in one column.