### PR TITLE
Moved dark mode switch logic to a separate JS file

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@ import hljs from 'highlight.js/lib/core'
 import php from 'highlight.js/lib/languages/php'
 import tippy from 'tippy.js'
 import './data/profile/avatarSettings'
+import './data/general/darkTheme'
 
 hljs.registerLanguage('php', php)
 hljs.highlightAll()

--- a/resources/js/data/general/darkTheme.js
+++ b/resources/js/data/general/darkTheme.js
@@ -1,0 +1,12 @@
+import Alpine from 'alpinejs'
+
+Alpine.data('darkTheme', () => ({
+    darkMode: localStorage.getItem('theme') === null
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : localStorage.getItem('theme') === 'dark',
+
+    toggle() {
+        this.darkMode = !this.darkMode
+        localStorage.setItem('theme', this.darkMode ? 'dark' : 'light')
+    },
+}))

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -1,16 +1,5 @@
 <!doctype html>
-<html :data-theme="darkMode ? 'dark' : 'light'" lang="en"
-      class="scroll-smooth"
-      x-cloak
-      x-data="{
-        darkMode: localStorage.getItem('theme') === null ? window.matchMedia('(prefers-color-scheme: dark)').matches : localStorage.getItem('theme') === 'dark',
-        toggle() {
-          this.darkMode = !this.darkMode;
-          localStorage.setItem('theme', this.darkMode ? 'dark' : 'light');
-        }
-      }"
-      :class="{ 'dark': darkMode }"
->
+<html class="scroll-smooth" lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -26,7 +15,14 @@
 
     @stack('meta')
 </head>
-<body class="min-h-screen flex flex-col bg-background transition-colors duration-300">
+
+<body
+    x-data="darkTheme"
+    x-cloak
+    :data-theme="darkMode ? 'dark' : 'light'"
+    :class="{ 'dark': darkMode }"
+    class="min-h-screen flex flex-col bg-background transition-colors duration-300"
+>
 
 @php
     $user = auth()->user();


### PR DESCRIPTION
Moved dark mode switching logic to a separate JavaScript file. Also moved dark mode logic from `<html>` to `<body>` tag.