### PR TITLE
Fixed small issue with system theme

### DIFF
--- a/resources/js/data/general/darkTheme.js
+++ b/resources/js/data/general/darkTheme.js
@@ -2,18 +2,22 @@ import Alpine from 'alpinejs'
 
 Alpine.data('darkTheme', () => ({
     darkMode: null,
+    switchType: 'system', // 'light', 'dark', 'system'
 
     /**
      * @param {'dark'|'light'|'system'} theme
      */
     toggle(theme) {
         if (theme === 'system') {
-            this.darkMode = null
+            this.darkMode = this._prefersDarkSystemTheme().matches
+            this.switchType = 'system'
             localStorage.removeItem('theme')
             return
         }
 
-        this.darkMode = !this.darkMode
+        this.darkMode = theme === 'dark'
+        this.switchType = this.darkMode ? 'dark' : 'light'
+
         localStorage.setItem('theme', this.darkMode ? 'dark' : 'light')
     },
 
@@ -26,15 +30,21 @@ Alpine.data('darkTheme', () => ({
 
         if (selectedTheme) {
             this.darkMode = selectedTheme === 'dark'
+            this.switchType = selectedTheme
             return
         }
 
-        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        const prefersDark = this._prefersDarkSystemTheme()
 
-        this.darkMode = systemTheme.matches
+        this.darkMode = prefersDark.matches
+        this.switchType = 'system'
 
-        systemTheme.addEventListener('change', ({ matches }) => {
+        prefersDark.addEventListener('change', ({ matches }) => {
             this.darkMode = matches
         })
     },
+
+    _prefersDarkSystemTheme() {
+        return window.matchMedia('(prefers-color-scheme: dark)')
+    }
 }))

--- a/resources/views/components/navbar/dark-mode-button.blade.php
+++ b/resources/views/components/navbar/dark-mode-button.blade.php
@@ -8,7 +8,7 @@
         data-tippy-content="Switch to light theme"
         class="{{ $styles }}"
         @click="toggle('light')"
-        x-show="darkMode === true"
+        x-show="switchType === 'dark'"
     >
         <x-icons.moon class="w-6 h-6 md:text-white" />
 
@@ -20,7 +20,7 @@
         data-tippy-content="Switch to system theme"
         class="{{ $styles }}"
         @click="toggle('system')"
-        x-show="darkMode === false"
+        x-show="switchType === 'light'"
     >
         <x-icons.sun class="w-6 h-6 md:text-white" />
 
@@ -32,7 +32,7 @@
         data-tippy-content="Switch to dark theme"
         class="{{ $styles }}"
         @click="toggle('dark')"
-        x-show="darkMode === null"
+        x-show="switchType === 'system'"
     >
         <x-icons.computer-desktop class="w-6 h-6 md:text-white" />
 


### PR DESCRIPTION
Fixed small issue with system theme. The bug was, when switching to the system theme and refreshing the page, the dark theme switch would turn to either moon or sun. Now, it will turn into a computer icon which signifies that the current theme is chosen "system".

