### PR TITLE
Add better styling for monospaced inline code samples

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -18,3 +18,7 @@ pre.shiki code {
     @apply max-w-[200px] lg:max-w-full !bg-inherit;
     overflow: initial !important;
 }
+
+.prose > p > code {
+    @apply before:content-none after:content-none bg-[#eff1f3] dark:bg-gray-700 px-2 py-[3px] rounded-md font-normal text-sm;
+}


### PR DESCRIPTION
Closes #397 

Added better styling for monospaced inline code samples. Similar to what GitHub has. Here are the screenshots:

### Dark theme
<img width="1076" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/3e7005cf-e17e-475d-a863-48667d9e426a">

### Light theme
<img width="1104" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/e722ae1a-02fe-4f6b-b0d9-826477e1117b">
