### PR TITLE
Change styles on "Read more" button on RFC card

### DIFF
--- a/resources/views/components/card-link.blade.php
+++ b/resources/views/components/card-link.blade.php
@@ -10,7 +10,7 @@
 <div {{dusk('card-link')}} class="{{ $flexDirection }} bg-rfc-card transition-all opacity-90 rounded-lg border border-divider flex justify-between gap-2 p-3 md:p-7 flex-1">
     {{ $slot }}
 
-    <div class="flex items-center justify-between mt-2">
+    <div class="flex items-center justify-between mt-5">
         <small>
             @isset($userVote)
                 <x-tag @class([
@@ -18,7 +18,7 @@
                     'text-agree' => $userVote->isYes(),
                     'text-disagree' => $userVote->isNo(),
                 ])>
-                    {{ __('You voted') }} {{ $userVote->value }}
+                    You voted {{ $userVote->value }}
                 </x-tag>
             @endisset
         </small>
@@ -27,9 +27,18 @@
             {{dusk('card-link-more')}}
             href="{{ $to }}"
             title="Navigate to the RFC"
-            class="text-main hover:text-main-dark dark:text-font dark:hover:text-font-second transition-colors"
+            @class([
+                'flex text-font items-center gap-2 bg-slate-100 border border-slate-200 px-4 pr-2 py-1.5 rounded-full',
+                'dark:bg-gray-800 dark:border-slate-600 dark:hover:border-slate-400',
+                'group transition-colors hover:border-slate-400 dark:hover:bg-background',
+            ])
         >
             Read more
+
+            <x-icons.arrow-up-empty @class([
+                'w-6 h-6 inline-block rotate-90 text-slate-700 dark:text-slate-300 transition-transform',
+                'group-hover:dark:text-slate-200 group-hover:text-slate-900 group-hover:scale-110',
+            ]) />
         </a>
     </div>
 </div>


### PR DESCRIPTION
Style changes of the "Read more" button on RFC card:

## Light theme
<img width="366" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/4b4f4962-6924-4e2d-bb99-60de5dc30be6">

## Dark theme
<img width="371" alt="image" src="https://github.com/brendt/rfc-vote/assets/35465417/06c26c2b-d977-4e7c-8e5a-ec97d49bd8eb">

It has a nice hover effect, which is not visible in the screenshot.

This PR is related to #391 issue where @theofidry mentioned that:

> When checking another RFCs, currently you see the small box with "Read more" and need to click on the "Read more" link to get there. Maybe the whole thumbnail could be a link instead?

As a solution, I think this small change will make it easier to go to an RFC page. Make the whole card as a link is not really possible because we'll need to remove all the links from the inside of the card, since in HTML, you can't have a link inside a link. There is a workaround using JavaScript and click event and `window.location.href = 'some link'`, but I don't think I want to do that.