### PR TITLE
Fixed typo and wrapped in localisation helper

### DIFF
--- a/resources/views/livewire/message-list.blade.php
+++ b/resources/views/livewire/message-list.blade.php
@@ -7,11 +7,11 @@
         @endforeach
 
         @if($user->inboxMessages->isEmpty())
-            <p class="text-lg opacity-60 text-font">There are not messages yet!</p>
+            <p class="text-lg opacity-60 text-font">{{ __('There are no messages yet!') }}</p>
         @endif
 
         @if($user->archivedMessages->isNotEmpty())
-            <h2 class="text-lg font-bold mb-2 mt-6">Archive</h2>
+            <h2 class="text-lg font-bold mb-2 mt-6">{{ __('Archive') }}</h2>
 
             @foreach($user->archivedMessages as $message)
                 <x-message-card.card :message="$message" />


### PR DESCRIPTION
Signed up to https://rfc.stitcher.io/ and noticed there was a small typo on the messages page.

Wrapped it in Laravel's localisation helper as well, hope that's ok!

Thanks. :) 