### PR TITLE
Fix error in vscode that md function is already defined

### DIFF
--- a/app/functions.php
+++ b/app/functions.php
@@ -2,10 +2,12 @@
 
 use League\CommonMark\MarkdownConverter;
 
-function md(string $contents): string
-{
-    /** @var MarkdownConverter $markdown */
-    $markdown = app(MarkdownConverter::class);
+if (! function_exists('md')) {
+    function md(string $contents): string
+    {
+        /** @var MarkdownConverter $markdown */
+        $markdown = app(MarkdownConverter::class);
 
-    return $markdown->convert($contents)->getContent();
+        return $markdown->convert($contents)->getContent();
+    }
 }


### PR DESCRIPTION
I opened a project with vscode, and got this error from `Laravel Extra Intellisense` plugin

![image](https://github.com/user-attachments/assets/52f2426d-3ccf-45b9-a4ad-84057cf8caa6)

The `md` function in `app/functions.php` file needs to be wrapped in `if (! function_exists('md')) }` statement to prevent fatal error.

In Laravel, wrapping the function declaration with if (! function_exists('md')) is a good practice to avoid redeclaring the function if it already exists. This can prevent potential errors or conflicts, especially if the function might be defined elsewhere in the application or by a package.

If the function `md` already exists and you try to declare it again without this check, PHP will throw a fatal error indicating that you cannot re-declare the function.