### PR TITLE
docs: fix php version for Sail command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run --rm \
    -u "$(id -u):$(id -g)" \
    -v "$(pwd):/var/www/html" \
    -w /var/www/html \
-   laravelsail/php82-composer:latest \
+   laravelsail/php83-composer:latest \
    composer install --ignore-platform-reqs
    ```
 2. copy `.env.example` to `.env`


### PR DESCRIPTION
Hello,

I think the PHP version in the Readme was not updated according to the minimum version entered in Composer, so it ended up breaking because of the PHP 8.3 typed constants

When I ran it:

```
docker run --rm \
   -u "$(id -u):$(id -g)" \
   -v "$(pwd):/var/www/html" \
   -w /var/www/html \
   laravelsail/php82-composer:latest \
   composer install --ignore-platform-reqs
```

```
ParseError 

  syntax error, unexpected identifier "STAY_UPDATED_MESSAGE", expecting "="

  at app/Http/Controllers/EnableEmailOptinController.php:10
      6▕ use Illuminate\Http\Request;
      7▕ 
      8▕ final readonly class EnableEmailOptinController
      9▕ {
  ➜  10▕     public const string STAY_UPDATED_MESSAGE = 'Stay updated! Get an email whenever a new RFC is added.';
     11▕ 
     12▕     public const string BUTTON_MESSAGE = 'Enable notifications';
     13▕ 
     14▕     public const string ENABLED_MESSAGE = 'Your email preferences were updated! You can change them at any time in your Settings.';
```